### PR TITLE
OnlineAd のいくつかのフィールドを OPTIONAL に変更

### DIFF
--- a/docs/opb/ca-model/online-ad.md
+++ b/docs/opb/ca-model/online-ad.md
@@ -39,7 +39,9 @@ REQUIRED. 必ず `["VerifiableCredential", "ContentAttestation"]` にしてく�
 - `description`: OPTIONAL. 広告の説明（文字列）。
 - `image`: OPTIONAL. 広告のサムネイル画像。サムネイル画像があるならば指定するべきです (RECOMMENDED)。 [`image` データ型](../context.md#the-image-datatype) の JSON-LD Node Object でなければなりません (MUST)。このプロパティで CA を[検証](../context.md#image-datatype-の検証)することができます。
 
-**注意:** `name` 、 `description` 、 `image` プロパティはそれぞれ OPTIONAL ですが、3つのうち少なくとも1つを含まなければなりません (MUST)。
+:::info[注意]
+`name` 、 `description` 、 `image` プロパティはそれぞれ OPTIONAL ですが、3つのうち少なくとも1つを含まなければなりません (MUST)。
+:::
 
 - `genre`: OPTIONAL. 文字列。
 - `landingPageUrl`: OPTIONAL. 広告をクリックした際、最終的に表示されるページ（ランディングページ）の URL 。

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/ca-model/online-ad.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/ca-model/online-ad.md
@@ -41,7 +41,9 @@ We plan to decide the extent to which we will comply with schema.org regarding t
 - `description`: OPTIONAL. It is ad description (plain text)
 - `image`: OPTIONAL. It is a thumbnail image for the ad. It is RECOMMENDED that a thumbnail image be specified if one is available. It MUST be a JSON-LD Node Object of type [`image` datatype](../context.md#the-image-datatype). This property allows you to [verify](../context.md#image-datatype-validate) the CA.
 
-**Note:** The `name`, `description`, and `image` properties are each OPTIONAL, but at least one of the three MUST be included.
+:::info[Attention]
+The `name`, `description`, and `image` properties are each OPTIONAL, but at least one of the three MUST be included.
+:::
 
 - `genre`: OPTIONAL. It is character string.
 - `landingPageUrl`: OPTIONAL. The URL of the page (landing page) that is ultimately displayed when the ad is clicked.


### PR DESCRIPTION
## 変更内容

(何を・なぜ変更したか)

- `name`、`description` プロパティを OPTIONAL に変更し、それに伴なって Note の記述を追加しました。

close #13 

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

(どうやって変更内容を確認した・してほしいか)

プレビューにて変更内容を確認し、内容等妥当かどうかご確認ください。

## レビュアー

(迷ったときは Copilot と [`shuf -n2 contributors...`](<https://gchq.github.io/CyberChef/#recipe=Shuffle('Line%20feed')Head('Line%20feed',2)&input=QFNhLVIzOTAKQHI3NHRlY2gKQGtvdTAyOXcKQG1ydDBhCkB5dXRzdWRhCkBrMW8wYjFhOQpAa25va21raTYxMgpAbm9idS10ZWNoYXJ0cw>) などで選出)

ランダムにて選出させていただきました。
@knokmki612 さん @nobu-techarts さん
お忙しい中お手数をおかけいたしますが、お手すきの際にご確認のほどよろしくお願いいたします。