### PR TITLE
PA credentialSubject.type の記述を CertificateProperties に統一

### DIFF
--- a/docs/opb/context.md
+++ b/docs/opb/context.md
@@ -271,7 +271,6 @@ _このセクションは非規範的です。_
         "genre": "https://schema.org/genre"
       }
     },
-    "Organization": "https://originator-profile.org/ns/cip/v1#Organization",
     "CertificateProperties": "https://originator-profile.org/ns/cip/v1#CertificateProperties",
     "Certificate": {
       "@id": "https://originator-profile.org/ns/cip/v1#Certificate",

--- a/docs/opb/pa-model/existence.md
+++ b/docs/opb/pa-model/existence.md
@@ -27,7 +27,7 @@ REQUIRED. [OP VC Data Model](../op-vc-data-model.md) に従ってください (M
 REQUIRED. 日本における実在性を表す JSON-LD Node Object です。
 
 - `id`: REQUIRED. 証明書保有組織の OP ID です。
-- `type`: REQUIRED. `Organization` にしてください。
+- `type`: REQUIRED. `CertificateProperties` にしてください。
 - `description`: OPTIONAL. この証明書に関する説明です（文字列）。
 - `name`: REQUIRED. 法人名
 - `corporateNumber`: REQUIRED. 法人番号

--- a/docs/opb/pa.md
+++ b/docs/opb/pa.md
@@ -76,7 +76,7 @@ PA の具体例を次に示します。この例ではいくつかのプロパ�
   "issuer": "dns:localhost",
   "credentialSubject": {
     "id": "dns:localhost",
-    "type": "Organization",
+    "type": "CertificateProperties",
     "addressCountry": "JP",
     "name": "Originator Profile 技術研究組合 (開発用)",
     "corporateNumber": "8010005035933",

--- a/docs/opb/securing-mechanism.md
+++ b/docs/opb/securing-mechanism.md
@@ -181,7 +181,7 @@ REQUIRED. [JWT (RFC 7519)](https://www.rfc-editor.org/rfc/rfc7519.html) の仕�
   "issuer": "dns:pa-issuer.example.org",
   "credentialSubject": {
     "id": "dns:pa-holder.example.jp",
-    "type": "ECJP",
+    "type": "CertificateProperties",
     "addressCountry": "JP",
     "name": "○○新聞社 (※開発用サンプル)",
     "corporateNumber": "0000000000000",

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/context.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/context.md
@@ -273,7 +273,6 @@ _This section is non-normative._
         "genre": "https://schema.org/genre"
       }
     },
-    "Organization": "https://originator-profile.org/ns/cip/v1#Organization",
     "CertificateProperties": "https://originator-profile.org/ns/cip/v1#CertificateProperties",
     "Certificate": {
       "@id": "https://originator-profile.org/ns/cip/v1#Certificate",

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/existence.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/existence.md
@@ -28,7 +28,7 @@ REQUIRED. It MUST comply with [OP VC Data Model](../op-vc-data-model.md) . In ad
 REQUIRED. It is JSON-LD Node Object that represents organization existence certificate.
 
 - `id`: REQUIRED. OP ID of the certificate holding organization.
-- `type`: REQUIRED. It should be `Organization`.
+- `type`: REQUIRED. It should be `CertificateProperties`.
 - `description`: OPTIONAL. A description of this certificate (string).
 - `name`: REQUIRED. Company name
 - `corporateNumber`: REQUIRED. Corporate number

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa.md
@@ -77,7 +77,7 @@ Below is an example of PA. In this example, there are a few more properties adde
   "issuer": "dns:localhost",
   "credentialSubject": {
     "id": "dns:localhost",
-    "type": "Organization",
+    "type": "CertificateProperties",
     "addressCountry": "JP",
     "name": "Originator Profile Collaborative Innovation Partnership (for develoment purposes)",
     "corporateNumber": "8010005035933",

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/securing-mechanism.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/securing-mechanism.md
@@ -181,7 +181,7 @@ Payload:
   "issuer": "dns:pa-issuer.example.org",
   "credentialSubject": {
     "id": "dns:pa-holder.example.jp",
-    "type": "ECJP",
+    "type": "CertificateProperties",
     "addressCountry": "JP",
     "name": "ABCD Newspaper (※Development Sample)",
     "corporateNumber": "0000000000000",


### PR DESCRIPTION
## 変更内容

(何を・なぜ変更したか)

- PA の credentialSubject.type の記述・例示ともに CertificateProperties に統一しました。

close #12 

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

(どうやって変更内容を確認した・してほしいか)

- プレビューにて変更内容を確認し、内容等妥当かどうかご確認ください。

## レビュアー

(迷ったときは Copilot と [`shuf -n2 contributors...`](<https://gchq.github.io/CyberChef/#recipe=Shuffle('Line%20feed')Head('Line%20feed',2)&input=QFNhLVIzOTAKQHI3NHRlY2gKQGtvdTAyOXcKQG1ydDBhCkB5dXRzdWRhCkBrMW8wYjFhOQpAa25va21raTYxMgpAbm9idS10ZWNoYXJ0cw>) などで選出)

ランダムにて選出させていただきました。
@yutsuda さん、 @r74tech さん
お忙しい中お手数をおかけいたしますが、お手すきの際にご確認のほどよろしくお願いいたします。