### PR TITLE
issue #40 翻訳更新: [opb/dns-uri-op-id.md] パーマリンクのみ更新

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/dns-uri-op-id.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/dns-uri-op-id.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 41
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/b10a57d/docs/opb/dns-uri-op-id.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/4a7db5d/docs/opb/dns-uri-op-id.md
 ---
 
 # DNS URI OP ID


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/opb/dns-uri-op-id.md)
-  [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/opb/dns-uri-op-id.md)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクの更新。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/4a7db5dec6c73d51444e4bef2c763938feb2eb6c) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/opb/dns-uri-op-id.md

## レビュアー

@yoshid8s レビューをお願いします。