### PR TITLE
issue #41 翻訳更新: [opb/index.mdx] パーマリンクのみ更新

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/index.mdx
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/dbfcb0d/docs/opb/index.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/5b4f656/docs/opb/index.mdx
 ---
 
 # Originator Profile Blueprint


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/opb/index.mdx)
-  [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/opb/index.mdx)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクの更新。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/5b4f656e55d012e2e2f5f80e697fd1b3c3b5d182) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/opb/index.mdx

## レビュアー

@yoshid8s レビューをお願いします。