### PR TITLE
issue #42 翻訳更新: [opb/link-to-html.md] パーマリンクのみ更新

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/link-to-html.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/link-to-html.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 34
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/b10a57d/docs/opb/link-to-html.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/28c3ada/docs/opb/link-to-html.md
 ---
 
 # Linking Content Attestation Set and Originator Profile Set to A HTML Document


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/opb/link-to-html.md)
-  [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/opb/link-to-html.md)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクの更新。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/28c3ada9fe2cba1f50a77bf1927f30783c16f6ec) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/opb/link-to-html.md

## レビュアー

@yoshid8s レビューをお願いします。