### PR TITLE
OPB: Profile Annotator PA & Certification System

### DIFF
--- a/docs/opb/certificate.md
+++ b/docs/opb/certificate.md
@@ -35,11 +35,7 @@ REQUIRED. 必ず `["VerifiableCredential", "Certificate"]` にしてください
 - `image`: OPTIONAL. [`image` データ型](./context.md#the-image-datatype) の JSON-LD Node Object でなければなりません (MUST)。このプロパティで Certificate の画像が改ざんされていないかを[検証](./context.md#image-datatype-の検証)することができます。
 - `certifier`: OPTIONAL. 認証機関の名前です。
 - `verifier`: OPTIONAL. 検証機関の名前です。
-- `certificationSystem.id`: REQUIRED. 認証制度の ID を URI 形式で指定してください。
-- `certificationSystem.type`: REQUIRED. `CertificationSystem` でなければなりません (MUST)。
-- `certificationSystem.name`: REQUIRED. 認証制度の名前です。
-- `certificationSystem.description`: OPTIONAL. 認証制度の説明です（文字列）。
-- `certificationSystem.ref`: RECOMMENDED. 認証制度の詳細を知るための人が読むためのページの URL です。
+- `certificationSystem`: REQUIRED. [認証制度](./pa-model/certification-system.md)でなければなりません (MUST)。
 
 :::note
 

--- a/docs/opb/pa-model/advertising-certification.md
+++ b/docs/opb/pa-model/advertising-certification.md
@@ -32,11 +32,7 @@ REQUIRED. 広告認証証明書を表す JSON-LD Node Object です。
 - `image`: OPTIONAL. [`image` データ型](../context.md#the-image-datatype) の JSON-LD Node Object でなければなりません (MUST)。このプロパティで Certificate の画像が改ざんされていないかを[検証](../context.md#image-datatype-の検証)することができます。
 - `certifier`: OPTIONAL. 認証機関の名前です。
 - `verifier`: OPTIONAL. 検証機関の名前です。
-- `certificationSystem.id`: REQUIRED. 認証制度の ID を URI 形式で指定してください。
-- `certificationSystem.type`: REQUIRED. `CertificationSystem` でなければなりません (MUST)。
-- `certificationSystem.name`: REQUIRED.　認証制度の名前です。
-- `certificationSystem.description`: OPTIONAL. 認証制度の説明です（文字列）。
-- `certificationSystem.ref`: RECOMMENDED. 認証制度の詳細を知るための人が読むためのページの URL です。
+- `certificationSystem`: REQUIRED. [認証制度](./certification-system.md)でなければなりません (MUST)。
 
 #### `validFrom`
 

--- a/docs/opb/pa-model/certification-system.md
+++ b/docs/opb/pa-model/certification-system.md
@@ -1,0 +1,54 @@
+---
+tags:
+  - Profile Annotation
+---
+
+# 認証制度
+
+認証制度は、Profile Annotation (PA) の発行根拠となる第三者認証制度を識別し、その詳細情報を提供するための PA のサブモデルです。
+
+## 用語
+
+本文書に説明のない用語については、[用語](../terminology.md)を参照してください。
+
+## 認証制度のデータモデル
+
+### プロパティ
+
+#### `id`
+
+REQUIRED. 認証制度の ID を URI 形式で指定してください。
+
+#### `type`
+
+REQUIRED. `CertificationSystem` でなければなりません (MUST)。
+
+#### `name`
+
+REQUIRED. 認証制度の名前です。
+
+#### `description`
+
+OPTIONAL. 認証制度の説明です（文字列）。
+
+#### `ref`
+
+RECOMMENDED. 認証制度の詳細を知るための人が読むためのページの URL です。
+
+## Appendix
+
+### 例
+
+_このセクションは非規範的です。_
+
+認証制度のデータモデルの具体例を次に示します。
+
+```json
+{
+  "id": "urn:uuid:14270f8f-9f1c-4f89-9fa4-8c93767a8404",
+  "type": "CertificationSystem",
+  "name": "<認証制度名>",
+  "description": "<認証制度の説明>",
+  "ref": "https://certification.example.org/about"
+}
+```

--- a/docs/opb/pa-model/existence.md
+++ b/docs/opb/pa-model/existence.md
@@ -36,11 +36,7 @@ REQUIRED. 日本における実在性を表す JSON-LD Node Object です。
 - `addressRegion`: REQUIRED. 都道府県
 - `addressLocality`: REQUIRED. 市区町村
 - `streetAddress`: REQUIRED. 番地・ビル名
-- `certificationSystem.id`: REQUIRED. 認証制度の ID を URI 形式で指定してください。
-- `certificationSystem.type`: REQUIRED. `CertificationSystem` でなければなりません (MUST)。
-- `certificationSystem.name`: REQUIRED. 認証制度の名前です。
-- `certificationSystem.description`: OPTIONAL. 認証制度の説明です（文字列）。
-- `certificationSystem.ref`: RECOMMENDED. 認証制度の詳細を知るための人が読むためのページの URL です。
+- `certificationSystem`: REQUIRED. [認証制度](./certification-system.md)でなければなりません (MUST)。
 
 :::note
 日本以外の組織実在性証明書のプロパティに関しては検討中です。

--- a/docs/opb/pa-model/municipality-certificate.md
+++ b/docs/opb/pa-model/municipality-certificate.md
@@ -32,11 +32,7 @@ REQUIRED. 自治体認証証明書を表す JSON-LD Node Object です。
 - `image`: OPTIONAL. [`image` データ型](../context.md#the-image-datatype) の JSON-LD Node Object でなければなりません (MUST)。このプロパティで Certificate の画像が改ざんされていないかを[検証](../context.md#image-datatype-の検証)することができます。
 - `certifier`: OPTIONAL. 認証機関の名前です。
 - `verifier`: OPTIONAL. 検証機関の名前です。
-- `certificationSystem.id`: REQUIRED. 認証制度の ID を URI 形式で指定してください。
-- `certificationSystem.type`: REQUIRED. `CertificationSystem` でなければなりません (MUST)。
-- `certificationSystem.name`: REQUIRED. 認証制度の名前です。
-- `certificationSystem.description`: OPTIONAL. 認証制度の説明です（文字列）。
-- `certificationSystem.ref`: RECOMMENDED. 認証制度の詳細を知るための人が読むためのページの URL です。
+- `certificationSystem`: REQUIRED. [認証制度](./certification-system.md)でなければなりません (MUST)。
 
 :::note
 

--- a/docs/opb/pa-model/news-media-registration.md
+++ b/docs/opb/pa-model/news-media-registration.md
@@ -44,11 +44,7 @@ REQUIRED. 証明書発行組織の OP ID です。
 - `image`: OPTIONAL. [`image` データ型](../context.md#the-image-datatype) の JSON-LD Node Object でなければなりません (MUST)。このプロパティで Certificate の画像が改ざんされていないかを[検証](../context.md#image-datatype-の検証)することができます。
 - `certifier`: OPTIONAL. 認証機関の名前です。
 - `verifier`: OPTIONAL. 検証機関の名前です。
-- `certificationSystem.id`: REQUIRED. 認証制度の ID を URI 形式で指定してください。
-- `certificationSystem.type`: REQUIRED. `CertificationSystem` でなければなりません (MUST)。
-- `certificationSystem.name`: REQUIRED. 認証制度の名前です。
-- `certificationSystem.description`: OPTIONAL. 認証制度の説明です（文字列）。
-- `certificationSystem.ref`: RECOMMENDED. 認証制度の詳細を知るための人が読むためのページの URL です。
+- `certificationSystem`: REQUIRED. [認証制度](./certification-system.md)でなければなりません (MUST)。
 
 #### `validFrom`
 

--- a/docs/opb/pa-model/pa-annotator.md
+++ b/docs/opb/pa-model/pa-annotator.md
@@ -1,0 +1,107 @@
+---
+tags:
+  - Base Model
+  - Profile Annotation
+---
+
+# Profile Annotator PA
+
+Profile Annotator PA は、OP レジストリが登録要件として認めている Profile Annotation 発行者であることを示すための PA です。
+
+## 用語
+
+本文書に説明のない用語については、[用語](../terminology.md)を参照してください。
+
+## Profile Annotator PA のデータモデル
+
+Profile Annotator PA は [Profile Annotation](../pa.md) に従います。
+
+### プロパティ
+
+#### `@context`
+
+REQUIRED. [OP VC Data Model](../op-vc-data-model.md) に従ってください (MUST)。さらに、3つ目の値を `"https://originator-profile.org/ns/cip/v1"` にしなければなりません (MUST)。
+
+#### `type`
+
+REQUIRED. 必ず `["VerifiableCredential", "ProfileAnnotation"]` にしてください (MUST)。
+
+#### `issuer`
+
+REQUIRED. OP レジストリの OP ID でなければなりません (MUST)。
+
+Profile Annotator PA は OP レジストリが発行する PA です。OP レジストリは Profile Annotator 候補の組織を審査し、適格と認めた場合にこの PA を発行します。
+
+#### `credentialSubject`
+
+- `id`: REQUIRED. Profile Annotator PA を保有する組織（Profile Annotator）の OP ID でなければなりません (MUST)。
+- `type`: REQUIRED. `ProfileAnnotator` でなければなりません (MUST)。
+- `description`: OPTIONAL. この Profile Annotator に関する説明です（文字列）。
+- `name`: REQUIRED. Profile Annotator の名称です（文字列）。
+- `issuanceCertificationSystem`: REQUIRED. この Profile Annotator が発行を認められている認証制度を一意に識別する URI の配列でなければなりません (MUST)。
+- `certificationSystem`: REQUIRED. Profile Annotator 登録制度を示す[認証制度](./certification-system.md)でなければなりません (MUST)。
+
+:::note
+
+Profile Annotator 登録制度の ID について、同じ OP レジストリが運営する Profile Annotator 登録制度で、登録要件が同一である場合は、同じ値であるべきです。
+
+:::
+
+## 検証
+
+Profile Annotator PA を受け取った検証者は、次の検証を行うことができます（SHOULD）：
+
+1. Profile Annotator PA が [OP VC Data Model](../op-vc-data-model.md) および [Securing Mechanism](../securing-mechanism.md) に従って検証可能であることを確認する
+2. `issuer` が信頼できる OP レジストリの OP ID であることを確認する
+3. Profile Annotator が発行した PA が準拠する認証制度の ID が、この Profile Annotator PA の `issuanceCertificationSystem` に含まれていることを確認する
+
+## ユースケース
+
+Profile Annotator PA は、次のようなユースケースで使用されます：
+
+- OP レジストリが、特定の PA を発行する資格を持つ組織を管理する
+- 検証者が、受け取った PA の発行者が適切な資格を持っているかを確認する
+- Profile Annotator が、自身の資格を証明する
+
+例えば、「組織実在性証明書」を発行できる認証機関を OP レジストリが認定する場合、その認証機関に対して Profile Annotator PA を発行します。検証者は、受け取った「組織実在性証明書」の発行者が持つ Profile Annotator PA を確認することで、その発行者が適切な資格を持っていることを検証できます。
+
+## Appendix
+
+### 例
+
+_このセクションは非規範的です。_
+
+Profile Annotator PA のデータモデルの具体例を次に示します。
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://originator-profile.org/ns/credentials/v1",
+    "https://originator-profile.org/ns/cip/v1",
+    {
+      "@language": "ja-JP"
+    }
+  ],
+  "type": ["VerifiableCredential", "ProfileAnnotation"],
+  "issuer": "dns:op-registry.example.org",
+  "credentialSubject": {
+    "id": "dns:pa-issuer.example.jp",
+    "type": "ProfileAnnotator",
+    "name": "株式会社〇〇認証機構",
+    "description": "組織実在性証明書および広告認証証明書の発行を認められた Profile Annotator です。",
+    "issuanceCertificationSystem": [
+      "urn:uuid:def09cbd-6e8e-4c73-856d-5e00dffde643",
+      "urn:uuid:8029ece0-b327-4a7e-b586-3e442cb82d92"
+    ],
+    "certificationSystem": {
+      "id": "urn:uuid:5927e1da-e422-47c8-a5b8-efa6f5a45dd7",
+      "name": "OP レジストリ Profile Annotator 登録制度",
+      "description": "OP レジストリが運営する Profile Annotator の登録制度です。登録要件を満たした組織に対して Profile Annotator PA を発行します。",
+      "ref": "https://op-registry.example.org/pa-issuer-registration"
+    }
+  }
+}
+```
+
+この例では、`dns:op-registry.example.org` という OP レジストリが、`dns:pa-issuer.example.jp` という組織に対して Profile Annotator PA を発行しています。この組織は2つの認証制度（組織実在性証明と広告認証）に準拠した PA を発行する資格を持っています。

--- a/docs/opb/terminology.md
+++ b/docs/opb/terminology.md
@@ -90,11 +90,11 @@ Content Integrity Descriptor が特定する DOM 要素。
 
 ## 認証制度 (Certification System)
 
-[Certificate](./certificate.md) が暗号論的に証明する情報が実際に事実であることを担保するための制度。認証機関によって運営される。
+[Profile Annotation](./pa.md) の発行根拠となる第三者[認証制度](./pa-model/certification-system.md)を識別し、その詳細情報を提供する。
 
 ## 認証機関 (Certifier)
 
-認証制度 (Certification System) を運用する主体。Certificate の発行者とは限らない。
+[認証制度 (Certification System)](./pa-model/certification-system.md) を運用する主体。Profile Annotation の発行者とは限らない。
 
 ## JSON-LD Node Object
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/certificate.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/certificate.md
@@ -37,10 +37,7 @@ REQUIRED. It MUST be `["VerifiableCredential", "Certificate"]`.
 - `certifier`: OPTIONAL. The name of the certification authority.
 - `verifier`: OPTIONAL. The name of the verification authority.
 - `certificationSystem.id`: REQUIRED. Please specify the ID of the certification system in URI format.
-- `certificationSystem.type`: REQUIRED. MUST be `CertificationSystem`.
-- `certificationSystem.name`: REQUIRED. The name of the certification system.
-- `certificationSystem.description`: OPTIONAL. A description of the certification system (string).
-- `certificationSystem.ref`: RECOMMENDED. A URL for people to read to find out more about the certification system.
+- `certificationSystem`: REQUIRED. MUST be a [Certification System](./pa-model/certification-system.md).
 
 :::note
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/advertising-certification.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/advertising-certification.md
@@ -33,11 +33,7 @@ REQUIRED. It is a JSON-LD Node Object representing an Advertising Certification 
 - `image`: OPTIONAL. MUST be a JSON-LD Node Object of type `image`. This property allows you to verify that the image in the Certificate has not been tampered with.
 - `certifier`: OPTIONAL. The name of the certification authority.
 - `verifier`: OPTIONAL. The name of the verifier.
-- `certificationSystem.id`: REQUIRED. Specify the ID of the certification system in URI format.
-- `certificationSystem.type`: REQUIRED. MUST be a `CertificationSystem`.
-- `certificationSystem.name`: REQUIRED. The name of the certification system.
-- `certificationSystem.description`: OPTIONAL. A description of the certification system (string).
-- `certificationSystem.ref`: RECOMMENDED. The URL of a page people can read to learn more about the certification system.
+- `certificationSystem`: REQUIRED. MUST be a [Certification System](./certification-system.md).
 
 #### `validFrom`
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/certification-system.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/certification-system.md
@@ -1,0 +1,56 @@
+---
+tags:
+  - Profile Annotation
+---
+
+> **Note:** This document is currently not translated into English. The content below is in Japanese. An English translation will be provided soon.
+
+# Certification System
+
+認証制度は、Profile Annotation (PA) の発行根拠となる第三者認証制度を識別し、その詳細情報を提供するための PA のサブモデルです。
+
+## 用語
+
+本文書に説明のない用語については、[用語](../terminology.md)を参照してください。
+
+## 認証制度のデータモデル
+
+### プロパティ
+
+#### `id`
+
+REQUIRED. 認証制度の ID を URI 形式で指定してください。
+
+#### `type`
+
+REQUIRED. `CertificationSystem` でなければなりません (MUST)。
+
+#### `name`
+
+REQUIRED. 認証制度の名前です。
+
+#### `description`
+
+OPTIONAL. 認証制度の説明です（文字列）。
+
+#### `ref`
+
+RECOMMENDED. 認証制度の詳細を知るための人が読むためのページの URL です。
+
+## Appendix
+
+### 例
+
+_このセクションは非規範的です。_
+
+認証制度のデータモデルの具体例を次に示します。
+
+```json
+{
+  "id": "urn:uuid:14270f8f-9f1c-4f89-9fa4-8c93767a8404",
+  "type": "CertificationSystem",
+  "name": "<認証制度名>",
+  "description": "<認証制度の説明>",
+  "ref": "https://certification.example.org/about"
+}
+```

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/existence.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/existence.md
@@ -37,11 +37,7 @@ REQUIRED. It is JSON-LD Node Object that represents organization existence certi
 - `addressRegion`: REQUIRED. Prefectures
 - `addressLocality`: REQUIRED. City,town,village
 - `streetAddress`: REQUIRED. Street address and building name
-- `certificationSystem.id`: REQUIRED. Specify the ID of the certification system in URI format.
-- `certificationSystem.type`: REQUIRED. It MUST be `CertificationSystem`.
-- `certificationSystem.name`: REQUIRED. The name of the certification system.
-- `certificationSystem.description`: OPTIONAL. Explaining the certification system (string).
-- `certificationSystem.ref`: RECOMMENDED. The URL of a human-readable page to learn more about the certification system.
+- `certificationSystem`: REQUIRED. MUST be a [Certification System](./certification-system.md).
 
 :::note
 The properties of the organization existence certificate outside of Japan are currently under consideration.

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/municipality-certificate.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/municipality-certificate.md
@@ -33,11 +33,7 @@ REQUIRED. It is a JSON-LD Node Object representing a Municipality Certification 
 - `image`: OPTIONAL. MUST be a JSON-LD Node Object of type `image`. This property allows you to verify that the image in the Certificate has not been tampered with.
 - `certifier`: OPTIONAL. The name of the certification authority.
 - `verifier`: OPTIONAL. The name of the verifier.
-- `certificationSystem.id`: REQUIRED. Specify the ID of the certification system in URI format.
-- `certificationSystem.type`: REQUIRED. MUST be a `CertificationSystem`.
-- `certificationSystem.name`: REQUIRED. The name of the certification system.
-- `certificationSystem.description`: OPTIONAL. A description of the certification system (string).
-- `certificationSystem.ref`: RECOMMENDED. The URL of a page people can read to learn more about the certification system.
+- `certificationSystem`: REQUIRED. MUST be a [Certification System](./certification-system.md).
 
 :::note
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/news-media-registration.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/news-media-registration.md
@@ -45,11 +45,7 @@ Currently, news media registration certificates are issued by OP registries that
 - `image`: OPTIONAL. It MUST be a JSON-LD Node Object of type [`image` datatype](../context.md#the-image-datatype). This property allows you to [verify](../context.md#image-datatype-validation) that the image in the Certificate has not been tampered with.
 - `certifier`: OPTIONAL. The name of the certification authority.
 - `verifier`: OPTIONAL. The name of the verifier.
-- `certificationSystem.id`: REQUIRED. Specify the ID of the certification system in URI format.
-- `certificationSystem.type`: REQUIRED. MUST be `CertificationSystem`.
-- `certificationSystem.name`: REQUIRED. The name of the certification system.
-- `certificationSystem.description`: OPTIONAL. A description of the certification system (string).
-- `certificationSystem.ref`: RECOMMENDED. A URL for people to read to find out more about the certification system.
+- `certificationSystem`: REQUIRED. MUST be a [Certification System](./certification-system.md).
 
 #### `validFrom`
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/pa-annotator.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/pa-annotator.md
@@ -1,0 +1,109 @@
+---
+tags:
+  - Base Model
+  - Profile Annotation
+---
+
+> **Note:** This document is currently not translated into English. The content below is in Japanese. An English translation will be provided soon.
+
+# Profile Annotator PA
+
+Profile Annotator PA は、OP レジストリが登録要件として認めている Profile Annotation 発行者であることを示すための PA です。
+
+## 用語
+
+本文書に説明のない用語については、[用語](../terminology.md)を参照してください。
+
+## Profile Annotator PA のデータモデル
+
+Profile Annotator PA は [Profile Annotation](../pa.md) に従います。
+
+### プロパティ
+
+#### `@context`
+
+REQUIRED. [OP VC Data Model](../op-vc-data-model.md) に従ってください (MUST)。さらに、3つ目の値を `"https://originator-profile.org/ns/cip/v1"` にしなければなりません (MUST)。
+
+#### `type`
+
+REQUIRED. 必ず `["VerifiableCredential", "ProfileAnnotation"]` にしてください (MUST)。
+
+#### `issuer`
+
+REQUIRED. OP レジストリの OP ID でなければなりません (MUST)。
+
+Profile Annotator PA は OP レジストリが発行する PA です。OP レジストリは Profile Annotator 候補の組織を審査し、適格と認めた場合にこの PA を発行します。
+
+#### `credentialSubject`
+
+- `id`: REQUIRED. Profile Annotator PA を保有する組織（Profile Annotator）の OP ID でなければなりません (MUST)。
+- `type`: REQUIRED. `ProfileAnnotator` でなければなりません (MUST)。
+- `description`: OPTIONAL. この Profile Annotator に関する説明です（文字列）。
+- `name`: REQUIRED. Profile Annotator の名称です（文字列）。
+- `issuanceCertificationSystem`: REQUIRED. この Profile Annotator が発行を認められている認証制度を一意に識別する URI の配列でなければなりません (MUST)。
+- `certificationSystem`: REQUIRED. Profile Annotator 登録制度を示す[認証制度](./certification-system.md)でなければなりません (MUST)。
+
+:::note
+
+Profile Annotator 登録制度の ID について、同じ OP レジストリが運営する Profile Annotator 登録制度で、登録要件が同一である場合は、同じ値であるべきです。
+
+:::
+
+## 検証
+
+Profile Annotator PA を受け取った検証者は、次の検証を行うことができます（SHOULD）：
+
+1. Profile Annotator PA が [OP VC Data Model](../op-vc-data-model.md) および [Securing Mechanism](../securing-mechanism.md) に従って検証可能であることを確認する
+2. `issuer` が信頼できる OP レジストリの OP ID であることを確認する
+3. Profile Annotator が発行した PA が準拠する認証制度の ID が、この Profile Annotator PA の `issuanceCertificationSystem` に含まれていることを確認する
+
+## ユースケース
+
+Profile Annotator PA は、次のようなユースケースで使用されます：
+
+- OP レジストリが、特定の PA を発行する資格を持つ組織を管理する
+- 検証者が、受け取った PA の発行者が適切な資格を持っているかを確認する
+- Profile Annotator が、自身の資格を証明する
+
+例えば、「組織実在性証明書」を発行できる認証機関を OP レジストリが認定する場合、その認証機関に対して Profile Annotator PA を発行します。検証者は、受け取った「組織実在性証明書」の発行者が持つ Profile Annotator PA を確認することで、その発行者が適切な資格を持っていることを検証できます。
+
+## Appendix
+
+### 例
+
+_このセクションは非規範的です。_
+
+Profile Annotator PA のデータモデルの具体例を次に示します。
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://originator-profile.org/ns/credentials/v1",
+    "https://originator-profile.org/ns/cip/v1",
+    {
+      "@language": "ja-JP"
+    }
+  ],
+  "type": ["VerifiableCredential", "ProfileAnnotation"],
+  "issuer": "dns:op-registry.example.org",
+  "credentialSubject": {
+    "id": "dns:pa-issuer.example.jp",
+    "type": "ProfileAnnotator",
+    "name": "株式会社〇〇認証機構",
+    "description": "組織実在性証明書および広告認証証明書の発行を認められた Profile Annotator です。",
+    "issuanceCertificationSystem": [
+      "urn:uuid:def09cbd-6e8e-4c73-856d-5e00dffde643",
+      "urn:uuid:8029ece0-b327-4a7e-b586-3e442cb82d92"
+    ],
+    "certificationSystem": {
+      "id": "urn:uuid:5927e1da-e422-47c8-a5b8-efa6f5a45dd7",
+      "name": "OP レジストリ Profile Annotator 登録制度",
+      "description": "OP レジストリが運営する Profile Annotator の登録制度です。登録要件を満たした組織に対して Profile Annotator PA を発行します。",
+      "ref": "https://op-registry.example.org/pa-issuer-registration"
+    }
+  }
+}
+```
+
+この例では、`dns:op-registry.example.org` という OP レジストリが、`dns:pa-issuer.example.jp` という組織に対して Profile Annotator PA を発行しています。この組織は2つの認証制度（組織実在性証明と広告認証）に準拠した PA を発行する資格を持っています。

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/terminology.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/terminology.md
@@ -96,11 +96,11 @@ The target element of a target integrity is converted to a string representation
 
 ## Certification System
 
-A system for cryptographically verifying that the information a [Certificate](./certificate.md) cryptographically attests to is actually true, operated by a certification authority.
+Identify the third-party [Certification System](./pa-model/certification-system.md) that serves as the basis for issuing a Profile Annotation, and provide detailed information about it.
 
 ## Certifier
 
-The entity that operates the certification system. It is not necessarily the issuer of the certificate.
+The entity that operates the [Certification System](./pa-model/certification-system.md). It is not necessarily the issuer of the Profile Annotation.
 
 ## JSON-LD Node Object
 


### PR DESCRIPTION
close https://github.com/originator-profile/docs.originator-profile.org/issues/6

https://github.com/originator-profile/cip.docs.originator-profile.org/pull/661 の続き

- 認証制度をPAのサブモデルとして文書化
- Profile Annotation Issuer -> Profile Annotator
- 語彙に関しては議論のたたき台としてcertificationSystemを踏襲した保守的な方向で案出し

## 確認手順

プレビュー:

- https://docs-originator-profile-gh-6.docs-originator-profile.pages.dev/ja/opb/pa-model/pa-annotator/
- https://docs-originator-profile-gh-6.docs-originator-profile.pages.dev/ja/opb/pa-model/certification-system/