### PR TITLE
issue #56 翻訳更新: [opb/pa.md] パーマリンクのみ更新

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 22
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/b10a57d/docs/opb/pa.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/188b3f2/docs/opb/pa.md
 tags:
   - Base Model
   - Profile Annotation


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/opb/pa.md)
-  [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/opb/pa.md)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクの更新。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/188b3f281f94aede32369cefef72104e78d15553) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/opb/pa.md

## レビュアー

@yoshid8s レビューをお願いします。