### PR TITLE
issue #59 翻訳更新: [opb/site-profile.md] パーマリンクのみ更新

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/site-profile.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/site-profile.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 33
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/b10a57d/docs/opb/site-profile.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/a3fb119/docs/opb/site-profile.md
 ---
 
 # Site Profile


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/opb/site-profile.md)
-  [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/opb/site-profile.md)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクの更新。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/a3fb1194ca02d67e0f10b9ff295190b50e71e2c9) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/opb/site-profile.md
## レビュアー

@yoshid8s レビューをお願いします。