### PR TITLE
issue #62 翻訳更新: [opb/website-profile.md] パーマリンクのみ更新

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/website-profile.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/website-profile.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 29
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/e851a21/docs/opb/website-profile.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/4d155cb/docs/opb/website-profile.md
 tags:
   - Web Media Specific Model
 ---


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/opb/website-profile.md)
-  [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/opb/website-profile.md)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクの更新。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/4d155cb9ba92762f5f2e55f4f30d52e782ee385d) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/opb/website-profile.md
## レビュアー

@yoshid8s レビューをお願いします。