### PR TITLE
issue #75 翻訳更新: [opb/ca-model/online-ad.md] パーマリンクのみ更新

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/ca-model/online-ad.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/ca-model/online-ad.md
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/b10a57d/docs/opb/ca-model/online-ad.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/10e55fd/docs/opb/ca-model/online-ad.md
 tags:
   - Content Attestation
   - Web Media Specific Model


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/opb/ca-model/online-ad.md)
-  [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/opb/ca-model/online-ad.md)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクの更新。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/10e55fd3de9d0ea321c785de63b66a9f2df732a2) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/opb/ca-model/online-ad.md

## レビュアー

@yoshid8s レビューをお願いします。