### PR TITLE
issue #80 翻訳更新: [opb/content-integrity-descriptor/visible-text.md] パーリンクのみ更新

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/content-integrity-descriptor/visible-text.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/content-integrity-descriptor/visible-text.md
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/b10a57d/docs/opb/content-integrity-descriptor/visible-text.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/4a7db5d/docs/opb/content-integrity-descriptor/visible-text.md
 tags:
   - Content Integrity Descriptor
   - Web Media Specific Model


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/opb/content-integrity-descriptor/visible-text.md)
-  [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/opb/content-integrity-descriptor/visible-text.md)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクの更新。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/4a7db5dec6c73d51444e4bef2c763938feb2eb6c) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/opb/content-integrity-descriptor/visible-text.md

## レビュアー

@yoshid8s レビューをお願いします。