### PR TITLE
issue #99 翻訳更新: [README.md] パーマリンク追加

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/README.md
@@ -1,3 +1,7 @@
+---
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/4df36c0/docs/README.md
+---
+
 # Originator Profile Docs
 
 ## Document Site


### PR DESCRIPTION
## 変更内容

翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）を追加しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/README.md)
-  [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/README.md)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクの追加のみです。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/4df36c06442ca5f2ab777c3ef07b08ed7bcf6fd8) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/README.md
## レビュアー

@yoshid8s レビューをお願いします。