### PR TITLE
issue #101 翻訳更新: [tech/about.mdx] パーマリンクのみ更新

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/tech/about.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/tech/about.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/e250880/docs/tech/about.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/b297ed4/docs/tech/about.mdx
 ---
 
 # What is an Originator Profile?


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/tech/about.mdx)
-  [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/tech/about.mdx)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクの更新。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/b297ed42028c2f05816d067c756a7c41e8deb86b) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/tech/about.mdx

## レビュアー

@yoshid8s レビューをお願いします。