### PR TITLE
issue #102 翻訳更新: [tech/index.mdx] パーマリンクのみ更新

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/tech/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/tech/index.mdx
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/812c4eb/docs/tech/index.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/e4f2583/docs/tech/index.mdx
 ---
 
 # About Originator Profile


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/tech/index.mdx)
-  [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/tech/index.mdx)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクの更新。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/e4f25833fe1716daf80b36c51777d0608fe364e0) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/tech/index.mdx
## レビュアー

@yoshid8s レビューをお願いします。