### PR TITLE
issue #103 翻訳更新: [tech/mechanism.mdx] パーマリンクのみ更新

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/tech/mechanism.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/tech/mechanism.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/3d0649e/docs/tech/mechanism.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/8d4e207/docs/tech/mechanism.mdx
 ---
 
 # The mechanism of Originator Profile


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/tech/mechanism.mdx)
-  [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/tech/mechanism.mdx)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクの更新。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/8d4e207ac6e3a293c5cb92bb8fb91041ba161cdb) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/tech/mechanism.mdx
## レビュアー

@yoshid8s レビューをお願いします。