### PR TITLE
CODEOWNERS の整備

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @originator-profile/techdev-wg


### PR DESCRIPTION
適切な GitHub Team を指定してコードの管理をおこなっているメンバーを明確にします

---

この変更により https://github.com/originator-profile/originator-profile/issues/106 と同じようにコードレビューに関する設定を自動化できるようにします (その設定を依頼する @kou029w さんに本変更が妥当か、お手すきの際にレビューお願いします。)