### PR TITLE
issue #115 翻訳更新: [opb/algorithm.md] パーマリンクのみ更新

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/algorithm.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/algorithm.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 103
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/a3fb119/docs/opb/algorithm.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/0ed3e2e/docs/opb/algorithm.md
 ---
 
 # Cryptographic algorithms


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/opb/algorithm.md)
-  [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/opb/algorithm.md)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクの更新。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/0ed3e2e61fa4f3314c370f73b5ef0f25bb9032be) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/opb/algorithm.md
## レビュアー

@yoshid8s レビューをお願いします。