### PR TITLE
Target Integrity Descriptor a要素の外部リソース検証に関する仕様の検討状況を反映

### DIFF
--- a/docs/opb/content-integrity-descriptor/external-resource.md
+++ b/docs/opb/content-integrity-descriptor/external-resource.md
@@ -131,29 +131,11 @@ External Resource Target:
 
 :::
 
-a 要素を External Resource Target から参照する場合の具体例を次に示します。
+:::note
 
-External Resource Target:
+a 要素の `href` 属性で指定された外部リソースを検証可能にするための仕様は検討中です。現在の検証プロセスでは `src` 属性または `currentSrc` プロパティを使用したリソース取得のみが定義されています。詳しくは GitHub Issue [#127](https://github.com/originator-profile/docs.originator-profile.org/issues/127) をご確認ください。
 
-```json
-[
-  {
-    "type": "ExternalResourceTargetIntegrity",
-    "integrity": "sha256-Ip3vuwzubwJnOlzeKQ0Gc+daDcMc7EOYnIqypOyn4bs="
-  }
-]
-```
-
-このとき Web ページの HTML の a 要素に次のように `integrity` 属性を付与します。
-
-```html
-<a
-  href="https://cdn.example.com/document.pdf"
-  integrity="sha256-Ip3vuwzubwJnOlzeKQ0Gc+daDcMc7EOYnIqypOyn4bs="
-  type="application/pdf"
-  >PDF</a
->
-```
+:::
 
 :::note 実装上の注意点
 


### PR DESCRIPTION
仕様上の未定義なので削除し、GitHub Issueへのリンクを追加することで現状を明確化しました。

Signed-off-by: Kohei Watanabe <nebel@fogtype.com>
