### PR TITLE
Fix typo in Content Integrity Type Registry

### DIFF
--- a/docs/opb/content-integrity-descriptor/index.mdx
+++ b/docs/opb/content-integrity-descriptor/index.mdx
@@ -22,7 +22,7 @@ Content Integrity Descriptor はコンテンツ内の特定の情報の完全性
 
 ## Content Integrity Type Registry \{#registry}
 
-- `HTMLTargetIntegrity`: [HTML Fragment Integrity](./html.md)
+- `HtmlTargetIntegrity`: [HTML Fragment Integrity](./html.md)
 - `TextTargetIntegrity`: [Text within DOM Integrity](./text.md)
 - `VisibleTextTargetIntegrity`: [Visible Text within DOM Integrity](./visible-text.md)
 - `ExternalResourceTargetIntegrity`: [External Resource Integrity](./external-resource.md)


### PR DESCRIPTION
`HtmlTargetIntegrity` であるべきところが一箇所だけ `HTMLTargetIntegrity` となっていたので修正です。