### PR TITLE
翻訳更新: [opb/content-integrity-descriptor/index.mdx] #139

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/content-integrity-descriptor/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/content-integrity-descriptor/index.mdx
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/4a7db5d/docs/opb/content-integrity-descriptor/index.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/c95c76b/docs/opb/content-integrity-descriptor/index.mdx
 tags:
   - Content Attestation
   - Content Integrity Descriptor
@@ -23,7 +23,7 @@ In addition, to avoid type name collisions, the defined Content Integrity Descri
 
 ## Content Integrity Type Registry \{#registry}
 
-- `HTMLTargetIntegrity`: [HTML Fragment Integrity](./html.md)
+- `HtmlTargetIntegrity`: [HTML Fragment Integrity](./html.md)
 - `TextTargetIntegrity`: [Text within DOM Integrity](./text.md)
 - `VisibleTextTargetIntegrity`: [Visible Text within DOM Integrity](./visible-text.md)
 - `ExternalResourceTargetIntegrity`: [External Resource Integrity](./external-resource.md)


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）と本文を更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/opb/content-integrity-descriptor/index.mdx)
-  [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/opb/content-integrity-descriptor/index.mdx)

差分は[Fix typo in Content Integrity Type Registry (#132) ](https://github.com/originator-profile/docs.originator-profile.org/commit/c95c76b1a45856e166ed151b1674263e69545e85)(https://github.com/originator-profile/docs.originator-profile.org/commit/c95c76b1a45856e166ed151b1674263e69545e85) です。

## 確認手順

- 該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/c95c76b1a45856e166ed151b1674263e69545e85) と一致している
- L26 が以下のように修正されている
```diff
- `HTMLTargetIntegrity`: [HTML Fragment Integrity](./html.md)
+ `HtmlTargetIntegrity`: [HTML Fragment Integrity](./html.md)
```

の2点修正されていればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/opb/content-integrity-descriptor/index.mdx

## レビュアー

@yoshid8s レビューをお願いします。
