### PR TITLE
翻訳更新: [opb/certificate.md] パーマリンクのみ更新 #144

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/certificate.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/certificate.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 23
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/08529c8/docs/opb/certificate.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/c759397/docs/opb/certificate.md
 tags:
   - Profile Annotation
 ---


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/opb/certificate.md)
- [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/opb/certificate.md)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクの更新。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/c75939775ea7f91aab11b15c30d3c47cff17b391) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/opb/certificate.md

## レビュアー

@yoshid8s レビューをお願いします。
