### PR TITLE
翻訳更新: [opb/pa-model/news-media-registration.md] パーマリンクのみ更新 #154

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/news-media-registration.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/news-media-registration.md
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/4a7db5d/docs/opb/pa-model/news-media-registration.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/c759397/docs/opb/pa-model/news-media-registration.md
 tags:
   - Jurisdiction Specific Model
   - Profile Annotation


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/opb/pa-model/news-media-registration.md)
- [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/news-media-registration.md)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクの更新。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/c75939775ea7f91aab11b15c30d3c47cff17b391) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/opb/pa-model/news-media-registration.md

## レビュアー

@yoshid8s レビューをお願いします。