### PR TITLE
翻訳更新: [opb/pa-model/profile-annotator-registration.md] パーマリンク追加 #156

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/profile-annotator-registration.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/profile-annotator-registration.md
@@ -1,4 +1,5 @@
 ---
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/c759397/docs/opb/pa-model/profile-annotator-registration.md
 tags:
   - Base Model
   - Profile Annotation


### PR DESCRIPTION
## 変更内容

日本語ページ、翻訳ページが新規追加されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）を追加しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/opb/pa-model/profile-annotator-registration.md)
- [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/profile-annotator-registration.md)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクのみ追加。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/c75939775ea7f91aab11b15c30d3c47cff17b391) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/opb/pa-model/profile-annotator-registration.md

## レビュアー

@yoshid8s レビューをお願いします。