### PR TITLE
Enable sticky comments in code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,3 +37,4 @@ jobs:
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           allowes_bots: "dependabot[bot],renovate[bot],copilot-swe-agent[bot]"
+          use_sticky_comment: true


### PR DESCRIPTION
これにより Claude Code Review によるコメントがひとつのコメントに集約されます

See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md#inputs