### PR TITLE
翻訳更新: [README.md] パーマリンクのみ更新 #177

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/README.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/README.md
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/4df36c0/docs/README.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/3e6d770/docs/README.md
 ---
 
 # Originator Profile Docs


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/README.md)
-  [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/README.md)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクの追加のみです。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/3e6d770d3a0dba4db52084b74b151cb91a3f7236) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/README.md
## レビュアー

@yoshid8s レビューをお願いします。