### PR TITLE
翻訳更新: [error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_VERIFY_FAILED.md] パーマリンクのみ更新 #195

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_VERIFY_FAILED.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_VERIFY_FAILED.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/d9582d4/docs/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_VERIFY_FAILED.md
 tags:
   - Error Reference
 ---


### PR DESCRIPTION
## 変更内容

日本語ページ、翻訳ページが新規追加されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）を追加しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_VERIFY_FAILED.md)
- [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_VERIFY_FAILED.md)


コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクのみ追加。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/d9582d4e04b6c890593afcccd4a4884b672676b9) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_VERIFY_FAILED.md

## レビュアー

@yoshid8s レビューをお願いします。