### PR TITLE
エラーリファレンスの URL を変更

### DIFF
--- a/docs/error-reference/ca/ERR_CONTENT_ATTESTATION_INVALID.md
+++ b/docs/error-reference/ca/ERR_CONTENT_ATTESTATION_INVALID.md
@@ -3,6 +3,7 @@ sidebar_position: 1
 tags:
   - Error Reference
   - Content Attestation
+slug: /error-reference/ERR_CONTENT_ATTESTATION_INVALID
 ---
 
 # ERR_CONTENT_ATTESTATION_INVALID

--- a/docs/error-reference/ca/ERR_CONTENT_ATTESTATION_VERIFY_FAILED.md
+++ b/docs/error-reference/ca/ERR_CONTENT_ATTESTATION_VERIFY_FAILED.md
@@ -4,6 +4,7 @@ tags:
   - Error Reference
   - Content Attestation
   - Content Integrity Descriptor
+slug: /error-reference/ERR_CONTENT_ATTESTATION_VERIFY_FAILED
 ---
 
 # ERR_CONTENT_ATTESTATION_VERIFY_FAILED

--- a/docs/error-reference/cas/ERR_CONTENT_ATTESTATION_SET_VERIFY_FAILED.md
+++ b/docs/error-reference/cas/ERR_CONTENT_ATTESTATION_SET_VERIFY_FAILED.md
@@ -3,6 +3,7 @@ sidebar_position: 1
 tags:
   - Error Reference
   - Content Attestation
+slug: /error-reference/ERR_CONTENT_ATTESTATION_SET_VERIFY_FAILED
 ---
 
 # ERR_CONTENT_ATTESTATION_SET_VERIFY_FAILED

--- a/docs/error-reference/credentials/ERR_FETCH_CREDENTIALS_MESSAGING_FAILED.md
+++ b/docs/error-reference/credentials/ERR_FETCH_CREDENTIALS_MESSAGING_FAILED.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 tags:
   - Error Reference
+slug: /error-reference/ERR_FETCH_CREDENTIALS_MESSAGING_FAILED
 ---
 
 # ERR_FETCH_CREDENTIALS_MESSAGING_FAILED

--- a/docs/error-reference/op/ERR_CERTIFICATE_EXPIRED.md
+++ b/docs/error-reference/op/ERR_CERTIFICATE_EXPIRED.md
@@ -3,6 +3,7 @@ sidebar_position: 1
 tags:
   - Error Reference
   - Profile Annotation
+slug: /error-reference/ERR_CERTIFICATE_EXPIRED
 ---
 
 # ERR_CERTIFICATE_EXPIRED

--- a/docs/error-reference/op/ERR_CORE_PROFILE_NOT_FOUND.md
+++ b/docs/error-reference/op/ERR_CORE_PROFILE_NOT_FOUND.md
@@ -5,6 +5,7 @@ tags:
   - Profile Annotation
   - Web Media Specific Model
   - Content Attestation
+slug: /error-reference/ERR_CORE_PROFILE_NOT_FOUND
 ---
 
 # ERR_CORE_PROFILE_NOT_FOUND

--- a/docs/error-reference/op/ERR_ORIGINATOR_PROFILE_INVALID.md
+++ b/docs/error-reference/op/ERR_ORIGINATOR_PROFILE_INVALID.md
@@ -4,6 +4,7 @@ tags:
   - Error Reference
   - Profile Annotation
   - Web Media Specific Model
+slug: /error-reference/ERR_ORIGINATOR_PROFILE_INVALID
 ---
 
 # ERR_ORIGINATOR_PROFILE_INVALID

--- a/docs/error-reference/op/ERR_ORIGINATOR_PROFILE_VERIFY_FAILED.md
+++ b/docs/error-reference/op/ERR_ORIGINATOR_PROFILE_VERIFY_FAILED.md
@@ -4,6 +4,7 @@ tags:
   - Error Reference
   - Profile Annotation
   - Web Media Specific Model
+slug: /error-reference/ERR_ORIGINATOR_PROFILE_VERIFY_FAILED
 ---
 
 # ERR_ORIGINATOR_PROFILE_VERIFY_FAILED

--- a/docs/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_INVALID.md
+++ b/docs/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_INVALID.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 tags:
   - Error Reference
+slug: /error-reference/ERR_ORIGINATOR_PROFILE_SET_INVALID
 ---
 
 # ERR_ORIGINATOR_PROFILE_SET_INVALID

--- a/docs/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_VERIFY_FAILED.md
+++ b/docs/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_VERIFY_FAILED.md
@@ -2,6 +2,7 @@
 sidebar_position: 2
 tags:
   - Error Reference
+slug: /error-reference/ERR_ORIGINATOR_PROFILE_SET_VERIFY_FAILED
 ---
 
 # ERR_ORIGINATOR_PROFILE_SET_VERIFY_FAILED

--- a/docs/error-reference/sp/ERR_SITE_PROFILE_FETCH_FAILED.md
+++ b/docs/error-reference/sp/ERR_SITE_PROFILE_FETCH_FAILED.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 tags:
   - Error Reference
+slug: /error-reference/ERR_SITE_PROFILE_FETCH_FAILED
 ---
 
 # ERR_SITE_PROFILE_FETCH_FAILED

--- a/docs/error-reference/sp/ERR_SITE_PROFILE_FETCH_INVALID.md
+++ b/docs/error-reference/sp/ERR_SITE_PROFILE_FETCH_INVALID.md
@@ -2,6 +2,7 @@
 sidebar_position: 2
 tags:
   - Error Reference
+slug: /error-reference/ERR_SITE_PROFILE_FETCH_INVALID
 ---
 
 # ERR_SITE_PROFILE_FETCH_INVALID

--- a/docs/error-reference/sp/ERR_SITE_PROFILE_INVALID.md
+++ b/docs/error-reference/sp/ERR_SITE_PROFILE_INVALID.md
@@ -2,6 +2,7 @@
 sidebar_position: 3
 tags:
   - Error Reference
+slug: /error-reference/ERR_SITE_PROFILE_INVALID
 ---
 
 # ERR_SITE_PROFILE_INVALID

--- a/docs/error-reference/sp/ERR_SITE_PROFILE_VERIFY_FAILED.md
+++ b/docs/error-reference/sp/ERR_SITE_PROFILE_VERIFY_FAILED.md
@@ -2,6 +2,7 @@
 sidebar_position: 4
 tags:
   - Error Reference
+slug: /error-reference/ERR_SITE_PROFILE_VERIFY_FAILED
 ---
 
 # ERR_SITE_PROFILE_VERIFY_FAILED

--- a/docs/error-reference/vc/ERR_VC_DECODE_FAILED.md
+++ b/docs/error-reference/vc/ERR_VC_DECODE_FAILED.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 tags:
   - Error Reference
+slug: /error-reference/ERR_VC_DECODE_FAILED
 ---
 
 # ERR_VC_DECODE_FAILED

--- a/docs/error-reference/vc/ERR_VC_VERIFY_FAILED.md
+++ b/docs/error-reference/vc/ERR_VC_VERIFY_FAILED.md
@@ -2,6 +2,7 @@
 sidebar_position: 2
 tags:
   - Error Reference
+slug: /error-reference/ERR_VC_VERIFY_FAILED
 ---
 
 # ERR_VC_VERIFY_FAILED

--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/ca/ERR_CONTENT_ATTESTATION_INVALID.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/ca/ERR_CONTENT_ATTESTATION_INVALID.md
@@ -4,6 +4,7 @@ original: https://github.com/originator-profile/docs.originator-profile.org/blob
 tags:
   - Error Reference
   - Content Attestation
+slug: /error-reference/ERR_CONTENT_ATTESTATION_INVALID
 ---
 
 # ERR_CONTENT_ATTESTATION_INVALID

--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/ca/ERR_CONTENT_ATTESTATION_VERIFY_FAILED.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/ca/ERR_CONTENT_ATTESTATION_VERIFY_FAILED.md
@@ -5,6 +5,7 @@ tags:
   - Error Reference
   - Content Attestation
   - Content Integrity Descriptor
+slug: /error-reference/ERR_CONTENT_ATTESTATION_VERIFY_FAILED
 ---
 
 # ERR_CONTENT_ATTESTATION_VERIFY_FAILED

--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/cas/ERR_CONTENT_ATTESTATION_SET_VERIFY_FAILED.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/cas/ERR_CONTENT_ATTESTATION_SET_VERIFY_FAILED.md
@@ -4,6 +4,7 @@ original: https://github.com/originator-profile/docs.originator-profile.org/blob
 tags:
   - Error Reference
   - Content Attestation
+slug: /error-reference/ERR_CONTENT_ATTESTATION_SET_VERIFY_FAILED
 ---
 
 # ERR_CONTENT_ATTESTATION_SET_VERIFY_FAILED

--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/credentials/ERR_FETCH_CREDENTIALS_MESSAGING_FAILED.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/credentials/ERR_FETCH_CREDENTIALS_MESSAGING_FAILED.md
@@ -3,6 +3,7 @@ sidebar_position: 1
 original: https://github.com/originator-profile/docs.originator-profile.org/blob/d9582d4/docs/error-reference/credentials/ERR_FETCH_CREDENTIALS_MESSAGING_FAILED.md
 tags:
   - Error Reference
+slug: /error-reference/ERR_FETCH_CREDENTIALS_MESSAGING_FAILED
 ---
 
 # ERR_FETCH_CREDENTIALS_MESSAGING_FAILED

--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/op/ERR_CERTIFICATE_EXPIRED.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/op/ERR_CERTIFICATE_EXPIRED.md
@@ -4,6 +4,7 @@ original: https://github.com/originator-profile/docs.originator-profile.org/blob
 tags:
   - Error Reference
   - Profile Annotation
+slug: /error-reference/ERR_CERTIFICATE_EXPIRED
 ---
 
 # ERR_CERTIFICATE_EXPIRED

--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/op/ERR_CORE_PROFILE_NOT_FOUND.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/op/ERR_CORE_PROFILE_NOT_FOUND.md
@@ -6,6 +6,7 @@ tags:
   - Profile Annotation
   - Web Media Specific Model
   - Content Attestation
+slug: /error-reference/ERR_CORE_PROFILE_NOT_FOUND
 ---
 
 # ERR_CORE_PROFILE_NOT_FOUND

--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/op/ERR_ORIGINATOR_PROFILE_INVALID.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/op/ERR_ORIGINATOR_PROFILE_INVALID.md
@@ -5,6 +5,7 @@ tags:
   - Error Reference
   - Profile Annotation
   - Web Media Specific Model
+slug: /error-reference/ERR_ORIGINATOR_PROFILE_INVALID
 ---
 
 # ERR_ORIGINATOR_PROFILE_INVALID

--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/op/ERR_ORIGINATOR_PROFILE_VERIFY_FAILED.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/op/ERR_ORIGINATOR_PROFILE_VERIFY_FAILED.md
@@ -5,6 +5,7 @@ tags:
   - Error Reference
   - Profile Annotation
   - Web Media Specific Model
+slug: /error-reference/ERR_ORIGINATOR_PROFILE_VERIFY_FAILED
 ---
 
 # ERR_ORIGINATOR_PROFILE_VERIFY_FAILED

--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_INVALID.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_INVALID.md
@@ -3,6 +3,7 @@ sidebar_position: 1
 original: https://github.com/originator-profile/docs.originator-profile.org/blob/d9582d4/docs/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_INVALID.md
 tags:
   - Error Reference
+slug: /error-reference/ERR_ORIGINATOR_PROFILE_SET_INVALID
 ---
 
 # ERR_ORIGINATOR_PROFILE_SET_INVALID

--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_VERIFY_FAILED.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_VERIFY_FAILED.md
@@ -3,6 +3,7 @@ sidebar_position: 2
 original: https://github.com/originator-profile/docs.originator-profile.org/blob/d9582d4/docs/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_VERIFY_FAILED.md
 tags:
   - Error Reference
+slug: /error-reference/ERR_ORIGINATOR_PROFILE_SET_VERIFY_FAILED
 ---
 
 # ERR_ORIGINATOR_PROFILE_SET_VERIFY_FAILED

--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/sp/ERR_SITE_PROFILE_FETCH_FAILED.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/sp/ERR_SITE_PROFILE_FETCH_FAILED.md
@@ -3,6 +3,7 @@ sidebar_position: 1
 original: https://github.com/originator-profile/docs.originator-profile.org/blob/d9582d4/docs/error-reference/sp/ERR_SITE_PROFILE_FETCH_FAILED.md
 tags:
   - Error Reference
+slug: /error-reference/ERR_SITE_PROFILE_FETCH_FAILED
 ---
 
 # ERR_SITE_PROFILE_FETCH_FAILED

--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/sp/ERR_SITE_PROFILE_FETCH_INVALID.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/sp/ERR_SITE_PROFILE_FETCH_INVALID.md
@@ -3,6 +3,7 @@ sidebar_position: 2
 original: https://github.com/originator-profile/docs.originator-profile.org/blob/d9582d4/docs/error-reference/sp/ERR_SITE_PROFILE_FETCH_INVALID.md
 tags:
   - Error Reference
+slug: /error-reference/ERR_SITE_PROFILE_FETCH_INVALID
 ---
 
 # ERR_SITE_PROFILE_FETCH_INVALID

--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/sp/ERR_SITE_PROFILE_INVALID.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/sp/ERR_SITE_PROFILE_INVALID.md
@@ -3,6 +3,7 @@ sidebar_position: 3
 original: https://github.com/originator-profile/docs.originator-profile.org/blob/d9582d4/docs/error-reference/sp/ERR_SITE_PROFILE_INVALID.md
 tags:
   - Error Reference
+slug: /error-reference/ERR_SITE_PROFILE_INVALID
 ---
 
 # ERR_SITE_PROFILE_INVALID

--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/sp/ERR_SITE_PROFILE_VERIFY_FAILED.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/sp/ERR_SITE_PROFILE_VERIFY_FAILED.md
@@ -3,6 +3,7 @@ sidebar_position: 4
 original: https://github.com/originator-profile/docs.originator-profile.org/blob/d9582d4/docs/error-reference/sp/ERR_SITE_PROFILE_VERIFY_FAILED.md
 tags:
   - Error Reference
+slug: /error-reference/ERR_SITE_PROFILE_VERIFY_FAILED
 ---
 
 # ERR_SITE_PROFILE_VERIFY_FAILED

--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/vc/ERR_VC_DECODE_FAILED.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/vc/ERR_VC_DECODE_FAILED.md
@@ -3,6 +3,7 @@ sidebar_position: 1
 original: https://github.com/originator-profile/docs.originator-profile.org/blob/d9582d4/docs/error-reference/vc/ERR_VC_DECODE_FAILED.md
 tags:
   - Error Reference
+slug: /error-reference/ERR_VC_DECODE_FAILED
 ---
 
 # ERR_VC_DECODE_FAILED

--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/vc/ERR_VC_VERIFY_FAILED.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/vc/ERR_VC_VERIFY_FAILED.md
@@ -3,6 +3,7 @@ sidebar_position: 2
 original: https://github.com/originator-profile/docs.originator-profile.org/blob/d9582d4/docs/error-reference/vc/ERR_VC_VERIFY_FAILED.md
 tags:
   - Error Reference
+slug: /error-reference/ERR_VC_VERIFY_FAILED
 ---
 
 # ERR_VC_VERIFY_FAILED


### PR DESCRIPTION
## 変更内容
https://github.com/originator-profile/originator-profile/issues/21#issuecomment-3924266799 より
- エラーコードに対するドキュメントの URL を `<ドキュメント>/error-reference/<エラーコード>/` としました。

## 確認手順
プレビューにて、エラーコードに対するドキュメントに関する URL が変更されていること、また変更後の URL に問題なくアクセスできるかをご確認ください。