### PR TITLE
エラーリファレンスの説明を追加

### DIFF
--- a/docs/error-reference/index.mdx
+++ b/docs/error-reference/index.mdx
@@ -1,7 +1,7 @@
 # エラーリファレンス
 
-Site Profile、Originator Profile Set、Content Attestation Set の検証について、検証失敗等のエラーコードに対するドキュメントです。
-それぞれエラーコードから原因や解決策を閲覧することができます。
+[拡張機能](https://github.com/originator-profile/originator-profile/releases) または [デバッガツール](https://playground.originator-profile.org/app/debugger) を利用して、Site Profile、Originator Profile Set、Content Attestation Set を検証する場合に表示される、検証失敗等のエラーコードに対するドキュメントです。
+それぞれエラーコードのページで発生原因や解決策を説明しています。
 
 ## エラーリスト
 


### PR DESCRIPTION
拡張機能だけでなくデバッガでも検証ができることに気付いてもらえること、それらの返すエラーであって CA Server のレスポンスの説明ではないことが分かるよう記載。 (CA Server エラーの説明も追加して行きたいがそれはまた別途)