### PR TITLE
翻訳更新: [error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_INVALID.md] パーマリンクのみ更新 #263

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_INVALID.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_INVALID.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/d9582d4/docs/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_INVALID.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/0eea912/docs/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_INVALID.md
 tags:
   - Error Reference
 slug: /error-reference/ERR_ORIGINATOR_PROFILE_SET_INVALID


### PR DESCRIPTION
## 変更内容

日本語ページ、翻訳ページが新規追加されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）を更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_INVALID.md)
- [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_INVALID.md)


コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクのみ更新。


## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/0eea9128445ff71f3bb4daebf98caf4c9516473e) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/error-reference/ops/ERR_ORIGINATOR_PROFILE_SET_INVALID.md

## レビュアー

@yoshid8s レビューをお願いします。