### PR TITLE
翻訳更新: [opb/pa-model/local-government-certification.md] パーマリンクのみ更新 #298

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/local-government-certification.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/local-government-certification.md
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/c759397/docs/opb/pa-model/local-government-certification.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/7d651b3/docs/opb/pa-model/local-government-certification.md
 tags:
   - Jurisdiction Specific Model
   - Profile Annotation


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/opb/pa-model/local-government-certification.md)
- [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/local-government-certification.md)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクの更新。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id(https://github.com/originator-profile/docs.originator-profile.org/commit/7d651b3486585d60e86878cea77392cd14b515c1) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/opb/pa-model/local-government-certification.md

## レビュアー

@yoshid8s レビューをお願いします。