### PR TITLE
fix: 英語ドキュメントのリンク末尾の余分スペースを削除

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/ca-model/article.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/ca-model/article.md
@@ -15,7 +15,7 @@ For terms not explained in this document, please see [Terminology](../terminolog
 
 ## Article Data Model
 
-Complies with [Content Attestation](../ca.md) .
+Complies with [Content Attestation](../ca.md).
 
 ### Property
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/advertising-certification.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/advertising-certification.md
@@ -16,7 +16,7 @@ For terms not explained in this document, please see [Terminology](../terminolog
 
 ## Advertising Certification PA Properties
 
-It MUST comply with [Profile Annotation](../pa.md) .
+It MUST comply with [Profile Annotation](../pa.md).
 
 ### Property
 
@@ -92,13 +92,13 @@ If you are using a previous format that extends [Certificate](../certificate.md)
 
 ## Advertising Certification Certificate Properties
 
-It MUST comply with [Certificate](../certificate.md) .
+It MUST comply with [Certificate](../certificate.md).
 
 ### Property
 
 #### `@context`
 
-REQUIRED. It MUST comply with [OP VC Data Model](../op-vc-data-model.md) . In addition, the third value MUST be `"https://originator-profile.org/ns/cip/v1"`.
+REQUIRED. It MUST comply with [OP VC Data Model](../op-vc-data-model.md). In addition, the third value MUST be `"https://originator-profile.org/ns/cip/v1"`.
 
 #### `credentialSubject`
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/existence.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/existence.md
@@ -16,7 +16,7 @@ For terms not explained in this document, please see [Terminology](../terminolog
 
 ## Organization Existence PA Properties
 
-It MUST comply with [Profile Annotation](../pa.md) .
+It MUST comply with [Profile Annotation](../pa.md).
 
 ### Property
 
@@ -110,7 +110,7 @@ Complies with [Certificate](../certificate.md).
 
 #### `@context`
 
-REQUIRED. It MUST comply with [OP VC Data Model](../op-vc-data-model.md) . In addition, the third value MUST be `"https://originator-profile.org/ns/cip/v1" `.
+REQUIRED. It MUST comply with [OP VC Data Model](../op-vc-data-model.md). In addition, the third value MUST be `"https://originator-profile.org/ns/cip/v1"`.
 
 #### `credentialSubject`
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/local-government-certification.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/local-government-certification.md
@@ -16,7 +16,7 @@ For terms not explained in this document, please see [Terminology](../terminolog
 
 ## Local Government Certification PA Properties
 
-It MUST comply with [Profile Annotation](../pa.md) .
+It MUST comply with [Profile Annotation](../pa.md).
 
 ### Property
 
@@ -92,13 +92,13 @@ If you are using a previous format that extends [Certificate](../certificate.md)
 
 ## Municipality Certification Certificate Properties
 
-It MUST comply with [Certificate](../certificate.md) .
+It MUST comply with [Certificate](../certificate.md).
 
 ### Property
 
 #### `@context`
 
-REQUIRED. It MUST comply with [OP VC Data Model](../op-vc-data-model.md) . In addition, the third value MUST be `"https://originator-profile.org/ns/cip/v1"`.
+REQUIRED. It MUST comply with [OP VC Data Model](../op-vc-data-model.md). In addition, the third value MUST be `"https://originator-profile.org/ns/cip/v1"`.
 
 #### `credentialSubject`
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/news-media-registration.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/news-media-registration.md
@@ -16,7 +16,7 @@ For terms not explained in this document, please see [Terminology](../terminolog
 
 ## News Media Registration PA Properties
 
-It MUST comply with [Profile Annotation](../pa.md) .
+It MUST comply with [Profile Annotation](../pa.md).
 
 ### Property
 
@@ -94,7 +94,7 @@ It MUST comply with [Certificate](../certificate.md).
 
 #### `@context`
 
-REQUIRED. It MUST comply with [OP VC Data Model](../op-vc-data-model.md) . In addition, the third value MUST be `"https://originator-profile.org/ns/cip/v1"`.
+REQUIRED. It MUST comply with [OP VC Data Model](../op-vc-data-model.md). In addition, the third value MUST be `"https://originator-profile.org/ns/cip/v1"`.
 
 #### `type`
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/terminology.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/terminology.md
@@ -15,7 +15,7 @@ Data summarizing VCs represented as the subject of a certain organization.
 
 ## Originator Profile Set (OPS)
 
-The data model and data representation defined in the [Originator Profile Set](./originator-profile-set.md) . Data summarizing VCs related to an organization.
+The data model and data representation defined in the [Originator Profile Set](./originator-profile-set.md). Data summarizing VCs related to an organization.
 
 ## OP VC Data Model Conforming Document (OP VC DM conforming document)
 


### PR DESCRIPTION
## 変更内容

(何を・なぜ変更したか)

- 英語ドキュメントの `[link] .` 形式（リンクと句点の間の余分なスペース）を削除しました（11 箇所）。
- `i18n/en/.../pa-model/existence.md` の文字列末尾バッククォート前の余分なスペース 1 箇所も同時に削除しました。

### 背景

PR #325 のレビュー時に、これらの余分スペースは main 由来の既存問題として発見しましたが、PR #325 の diff 範囲外だったため `Line could not be resolved` でインライン suggestion を貼ることができませんでした。本 PR で別途修正します。

加えて、全件 grep（`\)[[:space:]]+\.`）で再確認した際に `i18n/en/.../terminology.md` の同種箇所が新規発見されたため、計 12 箇所を一括で修正しています。

### 影響範囲

- 英語版のみ（日本語版に同パターンの問題なし）
- リンク先 URL は変更なし（純粋な空白削除のみ、表示上の差分は句点とリンクの距離のみ）

## 確認手順

(どうやって変更内容を確認した・してほしいか)

- ローカルで `pnpm exec docusaurus build` が `ja`/`en` 両ロケールで `[SUCCESS]` 完走することを確認済み（broken link 警告なし）。
- 修正後に `grep -rnE '\)[[:space:]]+\.' i18n/en/docusaurus-plugin-content-docs/current/opb/` が空であることを確認済み。
- プレビュー（Cloudflare Pages のブランチプレビュー）でレンダリングをご確認ください。