### PR TITLE
Content Attestation の拡張ポイントを明確化し Type Registry を定義

### DIFF
--- a/docs/opb/ca-model/index.mdx
+++ b/docs/opb/ca-model/index.mdx
@@ -10,3 +10,18 @@ tags:
 import DocCardList from "@theme/DocCardList";
 
 <DocCardList />
+
+## 登録プロセス
+
+新しい型の Content Attestation を作る場合、少なくとも次のことを定義してください (MUST):
+
+- 型名
+- プロパティ定義
+
+また、型名の衝突を避けるため、定義した Content Attestation は [Content Attestation Type Registry](#registry) に登録してください (MUST)。
+
+## Content Attestation Type Registry {#registry}
+
+- `Advertorial`: [Content Attestation of Advertorial](./advertorial.md)
+- `Article`: [Content Attestation of Article Type](./article.md)
+- `OnlineAd`: [Content Attestation of Online Ad Type](./online-ad.md)

--- a/docs/opb/ca.md
+++ b/docs/opb/ca.md
@@ -180,14 +180,13 @@ CA の具体例を示します。この CA は https://media.example.com/article
 
 ## 拡張性 {#extensibility}
 
-発行者は [OP VC Data Model](./op-vc-data-model.md) および本文書に未定義のプロパティを Content Attestation に追加してはなりません (MUST NOT) 。
-
-発行者は [OP VC Data Model](./op-vc-data-model.md) および本文書に未定義のプロパティを追加してもよいです (MAY) が、その場合は [Verifiable Credentials Data Model 2.0 セクション 5.2](https://www.w3.org/TR/vc-data-model-2.0/#extensibility)に従って拡張してください (RECOMMENDED)。
+発行者は [OP VC Data Model](./op-vc-data-model.md) および本文書に未定義のプロパティを追加してもよいです (MAY) が、その場合は[登録プロセス](./ca-model/index.mdx#登録プロセス)に従ってください (MUST)。
 
 :::info
 
 Originator Profile 技術研究組合が開発するアプリケーションで使用されるプロパティについては、次の Originator Profile Blueprint (OPB) 文書を参照してください。
 
+- [Advertorial Data Model](./ca-model/advertorial.md)
 - [Article Data Model](./ca-model/article.md)
 - [Online Ad Data Model](./ca-model/online-ad.md)
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/ca-model/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/ca-model/index.mdx
@@ -11,3 +11,18 @@ These are the data models of [Content Attestation](../ca.md) (CA). It specifies 
 import DocCardList from "@theme/DocCardList";
 
 <DocCardList />
+
+## Registration Process
+
+When creating a new type of Content Attestation, you MUST define at least the following:
+
+- Type name
+- Property definitions
+
+In addition, to avoid type name collisions, the defined Content Attestation MUST be registered in the [Content Attestation Type Registry](#registry).
+
+## Content Attestation Type Registry {#registry}
+
+- `Advertorial`: [Content Attestation of Advertorial](./advertorial.md)
+- `Article`: [Content Attestation of Article Type](./article.md)
+- `OnlineAd`: [Content Attestation of Online Ad Type](./online-ad.md)

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/ca.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/ca.md
@@ -181,14 +181,13 @@ The example includes properties not defined in this document, see [Extensibility
 
 ## Extensibility {#extensibility}
 
-Issuers MUST NOT add properties to a Content Attestation that are not defined in the [OP VC Data Model](./op-vc-data-model.md) and this document.
-
-Issuers MAY add properties that are not defined in the [OP VC Data Model](./op-vc-data-model.md) and this document, but are RECOMMENDED to do so as per [Verifiable Credentials Data Model 2.0 Section 5.2](https://www.w3.org/TR/vc-data-model-2.0/#extensibility).
+The issuer MAY add properties not defined in the [OP VC Data Model](./op-vc-data-model.md) and this document, but in such cases, they MUST follow the [registration process](./ca-model/index.mdx#registration-process).
 
 :::info
 
 For information about properties used in applications developed by the Originator Profile Collaborative Innovation Partnership, please refer to the following Originator Profile Blueprint (OPB) documents:
 
+- [Advertorial Data Model](./ca-model/advertorial.md)
 - [Article Data Model](./ca-model/article.md)
 - [Online Ad Data Model](./ca-model/online-ad.md)
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/ca.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/ca.md
@@ -181,7 +181,7 @@ The example includes properties not defined in this document, see [Extensibility
 
 ## Extensibility {#extensibility}
 
-The issuer MAY add properties not defined in the [OP VC Data Model](./op-vc-data-model.md) and this document, but in such cases, they MUST follow the [registration process](./ca-model/index.mdx#registration-process).
+The issuer MAY add properties not defined in the [OP VC Data Model](./op-vc-data-model.md) and this document, but in such cases, it MUST follow the [registration process](./ca-model/index.mdx#registration-process).
 
 :::info
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa.md
@@ -67,7 +67,7 @@ Furthermore, the name, description, and URL of the Profile Annotation Policy SHO
 
 ## Extensibility {#extensibility}
 
-The issuer MAY add properties not defined in the [OP VC Data Model](./op-vc-data-model.md) and this document, but in such cases, they MUST follow the [registration process](./pa-model/index.mdx#registration-process).
+The issuer MAY add properties not defined in the [OP VC Data Model](./op-vc-data-model.md) and this document, but in such cases, it MUST follow the [registration process](./pa-model/index.mdx#registration-process).
 
 ## Appendix
 


### PR DESCRIPTION
## Summary

close https://github.com/originator-profile/originator-profile/issues/56

- [originator-profile/originator-profile#56](https://github.com/originator-profile/originator-profile/issues/56) で求められた PA / CA の拡張点の仕様明確化のうち、**CA 側** に対応した。PA 側は既に `pa-model/` に「登録プロセス」と「Profile Annotation Type Registry」が文書化されているため、CA も同じパターンに揃えた
- `docs/opb/ca.md` の Extensibility セクションを書き直し: 「未定義プロパティを Content Attestation に追加してはなりません (MUST NOT)」と「追加してもよいです (MAY)」が並列していた矛盾を解消し、 PA と並列の規範 (MAY + 登録プロセス MUST) に統一した
- `docs/opb/ca-model/index.mdx` に **登録プロセス** と **Content Attestation Type Registry** セクションを新設 (`Advertorial` / `Article` / `OnlineAd` の 3 件を登録)
- info ブロックの参考リンクに Advertorial Data Model を追加し、`ca-model/` 配下の 3 文書と揃えた
- 英語版 (`i18n/en/.../ca.md`, `.../ca-model/index.mdx`) も同 PR 内で内容を反映

## 仕様判断

| 拡張点 | 規範強度 | 備考 |
|---|---|---|
| `credentialSubject` へ未定義プロパティ追加 | MAY | PA と揃える |
| CA トップレベルへ未定義プロパティ追加 | MAY | PA と同様、登録プロセスに乗せれば可 |
| 上記いずれも | 登録プロセスに従う (MUST) | `ca-model/index.mdx#登録プロセス` を参照 |

## 変更しなかったこと

英語版 frontmatter の `original:` コミットハッシュは更新していない。`scripts/check-original-commits.js` を本 PR 範囲外の翻訳漏れ検出機構として運用するため、ハッシュ更新は「翻訳更新: ... パーマリンクのみ更新」系の別 PR の責務として残した。

## Test plan

- [ ] https://ca-extensibility.docs-originator-profile.pages.dev/ から閲覧し記載を確認する
- [ ] `/ja/opb/ca/` の 拡張性セクションのリンクが `/ja/opb/ca-model/#登録プロセス` に解決される
- [ ] `/en/opb/ca/` の Extensibility セクションのリンクが `/en/opb/ca-model/#registration-process` に解決される

🤖 Generated with [Claude Code](https://claude.com/claude-code)