### PR TITLE
翻訳更新 [migrate docusaurus v3.9 to v3.10 (#338) ]の対象ファイル パーマリンクのみ更新 #346

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/ca-model/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/ca-model/index.mdx
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/4a7db5d/docs/opb/ca-model/index.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/ca-model/index.mdx
 tags:
   - Content Attestation
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/certificate.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/certificate.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 23
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/ff1666a/docs/opb/certificate.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/certificate.md
 tags:
   - Profile Annotation
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/content-integrity-descriptor/external-resource.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/content-integrity-descriptor/external-resource.md
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/39c1489/docs/opb/content-integrity-descriptor/external-resource.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/content-integrity-descriptor/external-resource.md
 tags:
   - Content Integrity Descriptor
   - Web Media Specific Model

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/content-integrity-descriptor/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/content-integrity-descriptor/index.mdx
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/c95c76b/docs/opb/content-integrity-descriptor/index.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/content-integrity-descriptor/index.mdx
 tags:
   - Content Attestation
   - Content Integrity Descriptor

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/context.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/context.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 102
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/7d651b3/docs/opb/context.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/context.md
 ---
 
 # Contexts, Vocabularies, and Types

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/op-vc-data-model.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/op-vc-data-model.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 11
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/28c3ada/docs/opb/op-vc-data-model.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/op-vc-data-model.md
 ---
 
 # OP VC Data Model

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/advertising-certification.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/advertising-certification.md
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/7d651b3/docs/opb/pa-model/advertising-certification.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/pa-model/advertising-certification.md
 tags:
   - Jurisdiction Specific Model
   - Profile Annotation

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/existence.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/existence.md
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/c759397/docs/opb/pa-model/existence.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/pa-model/existence.md
 tags:
   - Jurisdiction Specific Model
   - Profile Annotation

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/index.mdx
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/c759397/docs/opb/pa-model/index.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/pa-model/index.mdx
 tags:
   - Profile Annotation
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/local-government-certification.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/local-government-certification.md
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/7d651b3/docs/opb/pa-model/local-government-certification.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/pa-model/local-government-certification.md
 tags:
   - Jurisdiction Specific Model
   - Profile Annotation

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/news-media-registration.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa-model/news-media-registration.md
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/7d651b3/docs/opb/pa-model/news-media-registration.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/pa-model/news-media-registration.md
 tags:
   - Jurisdiction Specific Model
   - Profile Annotation


### PR DESCRIPTION
[migrate docusaurus v3.9 to v3.10 (#338) ] (https://github.com/originator-profile/docs.originator-profile.org/commit/fbd41a7cbdc95114192bdde6b162f65cf8d1b0a9) 
この修正で日本語ページと翻訳ページ両方とも更新されており、パーマリンクのみの更新となるため、一括で修正更新します。

合計11件です。


## 確認の方法

チェックスクリプトを使用してパーマリンクを更新しているので問題ないと思いますが以下の2点の確認をお願いします。

- 更新対象のファイル11件のパーマリンクのコミットIDが(https://github.com/originator-profile/docs.originator-profile.org/commit/fbd41a7cbdc95114192bdde6b162f65cf8d1b0a9) となっているか確認
- 翻訳ファイルそれぞれのパーマリンクが以下のように記載してあるか確認

https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/certificate.md
https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/context.md
https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/op-vc-data-model.md
https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/ca-model/index.mdx
https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/content-integrity-descriptor/external-resource.md
https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/content-integrity-descriptor/index.mdx
https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/pa-model/advertising-certification.md
https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/pa-model/existence.md
https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/pa-model/index.mdx
https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/pa-model/local-government-certification.md
https://github.com/originator-profile/docs.originator-profile.org/blob/fbd41a7/docs/opb/pa-model/news-media-registration.md

## レビュワー

@yoshid8s よろしくお願いします。