### PR TITLE
翻訳更新 [ドキュメントの拡張機能の名称を更新 (#344)] の対象ファイル パーマリンクのみ更新 #352

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/credentials/ERR_FETCH_CREDENTIALS_MESSAGING_FAILED.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/credentials/ERR_FETCH_CREDENTIALS_MESSAGING_FAILED.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/0eea912/docs/error-reference/credentials/ERR_FETCH_CREDENTIALS_MESSAGING_FAILED.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/error-reference/credentials/ERR_FETCH_CREDENTIALS_MESSAGING_FAILED.md
 tags:
   - Error Reference
 slug: /error-reference/ERR_FETCH_CREDENTIALS_MESSAGING_FAILED

--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/index.mdx
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/30e7d2c/docs/error-reference/index.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/error-reference/index.mdx
 ---
 
 # Error Code List

--- a/i18n/en/docusaurus-plugin-content-docs/current/error-reference/sp/ERR_SITE_PROFILE_FETCH_FAILED.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-reference/sp/ERR_SITE_PROFILE_FETCH_FAILED.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/0eea912/docs/error-reference/sp/ERR_SITE_PROFILE_FETCH_FAILED.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/error-reference/sp/ERR_SITE_PROFILE_FETCH_FAILED.md
 tags:
   - Error Reference
 slug: /error-reference/ERR_SITE_PROFILE_FETCH_FAILED

--- a/i18n/en/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/getting-started.md
@@ -1,4 +1,5 @@
 ---
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/getting-started.md
 sidebar_position: 100
 ---
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/ca.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/ca.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 25
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/a3fb119/docs/opb/ca.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/opb/ca.md
 tags:
   - Base Model
   - Content Attestation

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/content-attestation-set.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/content-attestation-set.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 32
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/a3fb119/docs/opb/content-attestation-set.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/opb/content-attestation-set.md
 ---
 
 # Content Attestation Set

--- a/i18n/en/docusaurus-plugin-content-docs/current/tech/mechanism.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/tech/mechanism.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/8d4e207/docs/tech/mechanism.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/tech/mechanism.mdx
 ---
 
 # The mechanism of Originator Profile

--- a/i18n/en/docusaurus-plugin-content-docs/current/troubleshooting/image-access-error.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/troubleshooting/image-access-error.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 0
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/10274dc/docs/troubleshooting/image-access-error.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/troubleshooting/image-access-error.md
 ---
 
 # No image displayed

--- a/i18n/en/docusaurus-plugin-content-docs/current/troubleshooting/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/troubleshooting/index.mdx
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/10274dc/docs/troubleshooting/index.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/troubleshooting/index.mdx
 ---
 
 # Troubleshooting

--- a/i18n/en/docusaurus-plugin-content-pages/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-pages/index.mdx
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/523c4b8/src/pages/index.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/src/pages/index.mdx
 ---
 
 # Originator Profile Docs


### PR DESCRIPTION
[ドキュメントの拡張機能の名称を更新 (#344)](https://github.com/originator-profile/docs.originator-profile.org/commit/ea02fd3aa66ecb5b7642070c26d89e79f4ae8afb)

この修正で日本語ページと翻訳ページ両方とも更新されており、パーマリンクのみの更新となるため、一括で修正更新します。
合計10件です。

## 確認の方法

チェックスクリプトを使用してパーマリンクを更新しているので問題ないと思いますが以下の2点の確認をお願いします。

-  更新対象のファイル10件のパーマリンクのコミットIDが(https://github.com/originator-profile/docs.originator-profile.org/commit/ea02fd3aa66ecb5b7642070c26d89e79f4ae8afb) となっているか確認
- 翻訳ファイルそれぞれのパーマリンクが以下のように記載してあるか確認

1. https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/getting-started.md
2. https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/error-reference/index.mdx
3. https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/opb/ca.md
4. https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/opb/content-attestation-set.md
5. https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/tech/mechanism.mdx
6. https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/troubleshooting/image-access-error.md
7. https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/troubleshooting/index.mdx
8. https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/error-reference/credentials/ERR_FETCH_CREDENTIALS_MESSAGING_FAILED.md
9. https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/error-reference/sp/ERR_SITE_PROFILE_FETCH_FAILED.md
10. https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/src/pages/index.mdx

## レビュワー

@yoshid8s よろしくお願いします。