### PR TITLE
翻訳更新 [OPVC CLI のガイドを追加 (#357)] の対象ファイルパーマリンクのみ更新 #363

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/debugger.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/debugger.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 360
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/414d960/docs/debugger.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/75f6d5a/docs/debugger.md
 ---
 
 # Debugger

--- a/i18n/en/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/getting-started.md
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/getting-started.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/75f6d5a/docs/getting-started.md
 sidebar_position: 100
 ---
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/ca.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/ca.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 25
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/opb/ca.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/75f6d5a/docs/opb/ca.md
 tags:
   - Base Model
   - Content Attestation

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/web-media-profile.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/web-media-profile.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 28
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/5fe8e60/docs/opb/web-media-profile.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/75f6d5a/docs/opb/web-media-profile.md
 tags:
   - Web Media Specific Model
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/website-profile.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/website-profile.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 29
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/5fe8e60/docs/opb/website-profile.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/75f6d5a/docs/opb/website-profile.md
 tags:
   - Web Media Specific Model
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/playground.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/playground.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 340
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/414d960/docs/playground.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/75f6d5a/docs/playground.md
 ---
 
 # Content Attestation Server Playground

--- a/i18n/en/docusaurus-plugin-content-pages/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-pages/index.mdx
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/src/pages/index.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/75f6d5a/src/pages/index.mdx
 ---
 
 # Originator Profile Docs


### PR DESCRIPTION
OPVC CLI のガイドを追加 (https://github.com/originator-profile/docs.originator-profile.org/pull/357)
commit id ( https://github.com/originator-profile/docs.originator-profile.org/commit/75f6d5a062437a57840c1583b2dd6c9c8152769f) 


この修正で日本語ページと翻訳ページ両方とも更新されており、パーマリンクのみの更新となるため、一括で修正更新します。
合計7件です。

## 確認の方法

チェックスクリプトを使用してパーマリンクを更新しているので問題ないと思いますが以下の2点の確認をお願いします。

-  更新対象のファイル7件のパーマリンクのコミットIDが ( https://github.com/originator-profile/docs.originator-profile.org/commit/75f6d5a062437a57840c1583b2dd6c9c8152769f)  となっているか確認
- 翻訳ファイルそれぞれのパーマリンクが以下のように記載してあるか確認

## 対象URL

1. https://github.com/originator-profile/docs.originator-profile.org/blob/75f6d5a/docs/debugger.md
2. https://github.com/originator-profile/docs.originator-profile.org/blob/75f6d5a/docs/getting-started.md
3. https://github.com/originator-profile/docs.originator-profile.org/blob/75f6d5a/docs/playground.md
4. https://github.com/originator-profile/docs.originator-profile.org/blob/75f6d5a/docs/opb/ca.md
5. https://github.com/originator-profile/docs.originator-profile.org/blob/75f6d5a/docs/opb/web-media-profile.md
6. https://github.com/originator-profile/docs.originator-profile.org/blob/75f6d5a/docs/opb/website-profile.md
7. https://github.com/originator-profile/docs.originator-profile.org/blob/75f6d5a/src/pages/index.mdx

## レビュワー

@yoshid8s よろしくお願いします。