### PR TITLE
翻訳更新: [getting-started.md] パーマリンクのみ更新 #429

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/getting-started.md
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/75f6d5a/docs/getting-started.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/e6b2767/docs/getting-started.md
 sidebar_position: 100
 ---
 


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/getting-started.md)
-  [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/docs/getting-started.md)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクの更新。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id (https://github.com/originator-profile/docs.originator-profile.org/commit/e6b27670169506c6d584ee8feacf3c0b993ca3f3) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/getting-started.md

## レビュアー

@yoshid8s レビューをお願いします。