### PR TITLE
翻訳更新: [opb/content-attestation-set.md] パーマリンクのみ更新 #433

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/content-attestation-set.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/content-attestation-set.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 32
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/ea02fd3/docs/opb/content-attestation-set.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/fd822e8/docs/opb/content-attestation-set.md
 ---
 
 # Content Attestation Set


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/opb/content-attestation-set.md)
-  [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/docs/opb/content-attestation-set.md)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクの更新。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id (https://github.com/originator-profile/docs.originator-profile.org/commit/fd822e82436321cb99991f1e7758a421f5e9e11d) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/opb/content-attestation-set.md

## レビュアー

@yoshid8s レビューをお願いします。