### PR TITLE
翻訳更新: [opvc-cli.md] パーマリンクのみ更新 #437

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/opvc-cli.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opvc-cli.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 330
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/484ee39/docs/opvc-cli.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/798ebea/docs/opvc-cli.md
 ---
 
 # OPVC CLI


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/docs/opvc-cli.md)
-  [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-docs/current/docs/opvc-cli.md)

コミット履歴は同じで差分なし。目視チェックでも差分なし。パーマリンクの更新。

## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id (https://github.com/originator-profile/docs.originator-profile.org/commit/798ebea8f9dede14b1832b2f23bc548939dc9968) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/docs/opvc-cli.md

## レビュアー

@yoshid8s レビューをお願いします。