### PR TITLE
翻訳更新[リファレンス実装開発ガイド等の公開 (#460)] パーマリンクのみ追加 #463

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/development/deprecation.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/development/deprecation.md
@@ -1,3 +1,6 @@
+---
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/e0e20e4/docs/development/deprecation.md
+---
 # API Deprecation Policy
 
 This document explains the API deprecation policy.

--- a/i18n/en/docusaurus-plugin-content-docs/current/development/deprecation.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/development/deprecation.md
@@ -1,6 +1,7 @@
 ---
 original: https://github.com/originator-profile/docs.originator-profile.org/blob/e0e20e4/docs/development/deprecation.md
 ---
+
 # API Deprecation Policy
 
 This document explains the API deprecation policy.

--- a/i18n/en/docusaurus-plugin-content-docs/current/development/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/development/index.mdx
@@ -1,6 +1,7 @@
 ---
 original: https://github.com/originator-profile/docs.originator-profile.org/blob/e0e20e4/docs/development/index.mdx
 ---
+
 # Reference Implementation Development Guide
 
 This page explains the method to run the project in your local environment.

--- a/i18n/en/docusaurus-plugin-content-docs/current/development/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/development/index.mdx
@@ -1,3 +1,6 @@
+---
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/e0e20e4/docs/development/index.mdx
+---
 # Reference Implementation Development Guide
 
 This page explains the method to run the project in your local environment.


### PR DESCRIPTION
[リファレンス実装開発ガイド等の公開 (#460) ](https://github.com/originator-profile/docs.originator-profile.org/commit/e0e20e472d4cd7af2d1f204aeaa9f936039829dd)

commit id: (https://github.com/originator-profile/docs.originator-profile.org/commit/e0e20e472d4cd7af2d1f204aeaa9f936039829dd)

この修正で日本語ページと翻訳ページ両方とも新規追加されており、パーマリンクのみ追加となるため、一括で修正更新します。

合計2件です。

## 確認の方法

チェックスクリプトを使用してパーマリンクを更新しているので問題ないと思いますが以下の2点の確認をお願いします。

-  更新対象のファイル2件のパーマリンクのコミットIDが ( https://github.com/originator-profile/docs.originator-profile.org/commit/e0e20e472d4cd7af2d1f204aeaa9f936039829dd)  となっているか確認
- 翻訳ファイルそれぞれのパーマリンクが以下のように記載してあるか確認


## 対象URL

1. https://github.com/originator-profile/docs.originator-profile.org/blob/e0e20e4/docs/development/deprecation.md
2. https://github.com/originator-profile/docs.originator-profile.org/blob/e0e20e4/docs/development/index.mdx


## レビュワー

@yoshid8s よろしくお願いします。