### PR TITLE
翻訳更新[OP, SP, CA の有効期間の説明ページを新設 (#459)] パーマリンクのみ更新 #467

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/development/deprecation.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/development/deprecation.md
@@ -1,3 +1,6 @@
+---
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/e0e20e4/docs/development/deprecation.md
+---
 # API Deprecation Policy
 
 This document explains the API deprecation policy.

--- a/i18n/en/docusaurus-plugin-content-docs/current/development/deprecation.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/development/deprecation.md
@@ -1,6 +1,7 @@
 ---
 original: https://github.com/originator-profile/docs.originator-profile.org/blob/e0e20e4/docs/development/deprecation.md
 ---
+
 # API Deprecation Policy
 
 This document explains the API deprecation policy.

--- a/i18n/en/docusaurus-plugin-content-docs/current/development/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/development/index.mdx
@@ -1,6 +1,7 @@
 ---
 original: https://github.com/originator-profile/docs.originator-profile.org/blob/e0e20e4/docs/development/index.mdx
 ---
+
 # Reference Implementation Development Guide
 
 This page explains the method to run the project in your local environment.

--- a/i18n/en/docusaurus-plugin-content-docs/current/development/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/development/index.mdx
@@ -1,3 +1,6 @@
+---
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/e0e20e4/docs/development/index.mdx
+---
 # Reference Implementation Development Guide
 
 This page explains the method to run the project in your local environment.

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/cp.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/cp.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 21
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/c6370d4/docs/opb/cp.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/opb/cp.md
 tags:
   - Base Model
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/op-vc-data-model.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/op-vc-data-model.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 11
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/c6370d4/docs/opb/op-vc-data-model.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/opb/op-vc-data-model.md
 ---
 
 # OP VC Data Model

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 22
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/c6370d4/docs/opb/pa.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/opb/pa.md
 tags:
   - Base Model
   - Profile Annotation

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/web-media-profile.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/web-media-profile.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 28
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/c6370d4/docs/opb/web-media-profile.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/opb/web-media-profile.md
 tags:
   - Web Media Specific Model
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/website-profile.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/website-profile.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 29
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/c6370d4/docs/opb/website-profile.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/opb/website-profile.md
 tags:
   - Web Media Specific Model
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/tech/mechanism.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/tech/mechanism.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/c6370d4/docs/tech/mechanism.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/tech/mechanism.mdx
 ---
 
 # The mechanism of Originator Profile

--- a/i18n/en/docusaurus-plugin-content-docs/current/tech/validity-period.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/tech/validity-period.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/2435e06/docs/tech/validity-period.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/tech/validity-period.mdx
 ---
 
 # Validity period of OP, SP, and CA


### PR DESCRIPTION
[OP, SP, CA の有効期間の説明ページを新設 (#459)](https://github.com/originator-profile/docs.originator-profile.org/commit/ae499160b43fc8fc01c73aae67849b2cdbcf41c2)

commid id (https://github.com/originator-profile/docs.originator-profile.org/commit/ae499160b43fc8fc01c73aae67849b2cdbcf41c2)

この修正で日本語ページと翻訳ページ両方とも更新されており、パーマリンクのみの更新となるため、一括で修正更新します。

同時にコミットしているファイルがありますがさらに更新しているため別issue で登録しています。(#465, #466)

## 確認の方法

チェックスクリプトを使用してパーマリンクを更新しているので問題ないと思いますが以下の2点の確認をお願いします。

-  更新対象のファイル7件のパーマリンクのコミットIDが ( https://github.com/originator-profile/docs.originator-profile.org/commit/ae499160b43fc8fc01c73aae67849b2cdbcf41c2)  となっているか確認
- 翻訳ファイルそれぞれのパーマリンクが以下のように記載してあるか確認


## 対象URL 7件

1. https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/opb/cp.md
2. https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/opb/op-vc-data-model.md
3. https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/opb/pa.md
4. https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/opb/web-media-profile.md
5. https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/opb/website-profile.md
6. https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/tech/mechanism.mdx
7. https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/tech/validity-period.mdx



## レビュワー

@yoshid8s よろしくお願いします。