### PR TITLE
翻訳更新: [src/pages/index.mdx] パーマリンクのみ更新 #468

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/development/deprecation.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/development/deprecation.md
@@ -1,3 +1,6 @@
+---
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/e0e20e4/docs/development/deprecation.md
+---
 # API Deprecation Policy
 
 This document explains the API deprecation policy.

--- a/i18n/en/docusaurus-plugin-content-docs/current/development/deprecation.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/development/deprecation.md
@@ -1,6 +1,7 @@
 ---
 original: https://github.com/originator-profile/docs.originator-profile.org/blob/e0e20e4/docs/development/deprecation.md
 ---
+
 # API Deprecation Policy
 
 This document explains the API deprecation policy.

--- a/i18n/en/docusaurus-plugin-content-docs/current/development/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/development/index.mdx
@@ -1,6 +1,7 @@
 ---
 original: https://github.com/originator-profile/docs.originator-profile.org/blob/e0e20e4/docs/development/index.mdx
 ---
+
 # Reference Implementation Development Guide
 
 This page explains the method to run the project in your local environment.

--- a/i18n/en/docusaurus-plugin-content-docs/current/development/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/development/index.mdx
@@ -1,3 +1,6 @@
+---
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/e0e20e4/docs/development/index.mdx
+---
 # Reference Implementation Development Guide
 
 This page explains the method to run the project in your local environment.

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/cp.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/cp.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 21
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/c6370d4/docs/opb/cp.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/opb/cp.md
 tags:
   - Base Model
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/op-vc-data-model.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/op-vc-data-model.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 11
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/c6370d4/docs/opb/op-vc-data-model.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/opb/op-vc-data-model.md
 ---
 
 # OP VC Data Model

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/pa.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/pa.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 22
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/c6370d4/docs/opb/pa.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/opb/pa.md
 tags:
   - Base Model
   - Profile Annotation

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/web-media-profile.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/web-media-profile.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 28
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/c6370d4/docs/opb/web-media-profile.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/opb/web-media-profile.md
 tags:
   - Web Media Specific Model
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/opb/website-profile.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/opb/website-profile.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 29
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/c6370d4/docs/opb/website-profile.md
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/opb/website-profile.md
 tags:
   - Web Media Specific Model
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/tech/mechanism.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/tech/mechanism.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/c6370d4/docs/tech/mechanism.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/tech/mechanism.mdx
 ---
 
 # The mechanism of Originator Profile

--- a/i18n/en/docusaurus-plugin-content-docs/current/tech/validity-period.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/tech/validity-period.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/2435e06/docs/tech/validity-period.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ae49916/docs/tech/validity-period.mdx
 ---
 
 # Validity period of OP, SP, and CA

--- a/i18n/en/docusaurus-plugin-content-pages/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-pages/index.mdx
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/798ebea/src/pages/index.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/e0e20e4/src/pages/index.mdx
 ---
 
 # Originator Profile Docs


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/src/pages/index.mdx)
- [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-pages/index.mdx)

履歴は同じです。(https://github.com/originator-profile/docs.originator-profile.org/commit/e0e20e472d4cd7af2d1f204aeaa9f936039829dd)


## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id (https://github.com/originator-profile/docs.originator-profile.org/commit/e0e20e472d4cd7af2d1f204aeaa9f936039829dd) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/src/pages/index.mdx

## レビュアー

@yoshid8s レビューをお願いします。