### PR TITLE
CA サーバーのエラーリファレンスに OPS 検証エラーについての案内を追加

### DIFF
--- a/docs/error-reference/ca-server/400-bad-request.md
+++ b/docs/error-reference/ca-server/400-bad-request.md
@@ -83,6 +83,6 @@ sidebar_position: 1
 
 - [Prisma Error Reference](https://www.prisma.io/docs/orm/reference/error-reference)
 - [Site Profile](../../opb/site-profile.md)
-- [Orignator Profile Set](../../opb/originator-profile-set.md)
+- [Originator Profile Set](../../opb/originator-profile-set.md)
 - [Site Profile に関するエラーリファレンス](/error-reference/op-inspector-debugger/sp)
 - [Originator Profile Set に関するエラーリファレンス](/error-reference/op-inspector-debugger/ops)

--- a/docs/error-reference/ca-server/400-bad-request.md
+++ b/docs/error-reference/ca-server/400-bad-request.md
@@ -23,7 +23,9 @@ sidebar_position: 1
   （詳細は [Prisma のエラーリファレンス](https://www.prisma.io/docs/orm/reference/error-reference#prismaclientknownrequesterror)を参照してください。）
 - Web Media Profile または Profile Annotation の登録・更新時に `credentialSubject.id` が含まれていない可能性があります。
 - Site Profile の登録・更新時に、Site Profile の検証に失敗した可能性があります。
-  （詳細は [Site Profile](../../opb/site-profile.md) を参照してください。）
+  （詳細は [Site Profile の検証プロセス](../../opb/site-profile.md#verification)を参照してください。）
+- また、Site Profile の検証の一環として Originator Profile Set の検証を行うため、Originator Profile Set の検証に失敗した可能性があります。
+  （詳細は [Originator Profile Set の検証プロセス](../../opb/originator-profile-set.md#verification)を参照してください。）
 
 ## 例
 
@@ -74,9 +76,13 @@ sidebar_position: 1
 - 入力 JSON の必須項目・型・フォーマットまたはレスポンスメッセージのエラー内容を確認してください。
 - PrismaClientKnownRequestError が発生している場合は、Prisma のエラーリファレンスを参照してください。
 - Web Media Profile・Profile Annotation の `credentialSubject.id` は必ず含めてください。
-- Site Profile の検証が通るよう、入力内容を修正してください。
+- Site Profile または Originator Profile Set の検証が通るよう、入力内容を修正してください。  
+  （Site Profile、Originator Profile Set の検証に失敗した場合は [Site Profile に関するエラーリファレンス](/error-reference/op-inspector-debugger/sp)や [Originator Profile Set に関するエラーリファレンス](/error-reference/op-inspector-debugger/ops)を参照することで、原因の特定に役立つことがあります。）
 
 ## 関連情報
 
 - [Prisma Error Reference](https://www.prisma.io/docs/orm/reference/error-reference)
 - [Site Profile](../../opb/site-profile.md)
+- [Orignator Profile Set](../../opb/originator-profile-set.md)
+- [Site Profile に関するエラーリファレンス](/error-reference/op-inspector-debugger/sp)
+- [Originator Profile Set に関するエラーリファレンス](/error-reference/op-inspector-debugger/ops)

--- a/docs/error-reference/ca-server/400-bad-request.md
+++ b/docs/error-reference/ca-server/400-bad-request.md
@@ -23,9 +23,9 @@ sidebar_position: 1
   （詳細は [Prisma のエラーリファレンス](https://www.prisma.io/docs/orm/reference/error-reference#prismaclientknownrequesterror)を参照してください。）
 - Web Media Profile または Profile Annotation の登録・更新時に `credentialSubject.id` が含まれていない可能性があります。
 - Site Profile の登録・更新時に、Site Profile の検証に失敗した可能性があります。
-  （詳細は [Site Profile の検証プロセス](../../opb/site-profile.md#verification)を参照してください。）
+  （詳細は [Site Profile に関するエラーリファレンス](/error-reference/op-inspector-debugger/sp)を参照してください。）
 - また、Site Profile の検証の一環として Originator Profile Set の検証を行うため、Originator Profile Set の検証に失敗した可能性があります。
-  （詳細は [Originator Profile Set の検証プロセス](../../opb/originator-profile-set.md#verification)を参照してください。）
+  （詳細は [Originator Profile Set に関するエラーリファレンス](/error-reference/op-inspector-debugger/ops)や [Originator Profile に関するエラーリファレンス](/error-reference/op-inspector-debugger/op)を参照してください。）
 
 ## 例
 
@@ -77,7 +77,7 @@ sidebar_position: 1
 - PrismaClientKnownRequestError が発生している場合は、Prisma のエラーリファレンスを参照してください。
 - Web Media Profile・Profile Annotation の `credentialSubject.id` は必ず含めてください。
 - Site Profile または Originator Profile Set の検証が通るよう、入力内容を修正してください。  
-  （Site Profile、Originator Profile Set の検証に失敗した場合は [Site Profile に関するエラーリファレンス](/error-reference/op-inspector-debugger/sp)や [Originator Profile Set に関するエラーリファレンス](/error-reference/op-inspector-debugger/ops)を参照することで、原因の特定に役立つことがあります。）
+  （Site Profile、Originator Profile Set の検証に失敗した場合は [Site Profile に関するエラーリファレンス](/error-reference/op-inspector-debugger/sp)や [Originator Profile Set に関するエラーリファレンス](/error-reference/op-inspector-debugger/ops)、[Originator Profile に関するエラーリファレンス](/error-reference/op-inspector-debugger/op)を参照することで、原因の特定に役立つことがあります。）
 
 ## 関連情報
 
@@ -86,3 +86,4 @@ sidebar_position: 1
 - [Originator Profile Set](../../opb/originator-profile-set.md)
 - [Site Profile に関するエラーリファレンス](/error-reference/op-inspector-debugger/sp)
 - [Originator Profile Set に関するエラーリファレンス](/error-reference/op-inspector-debugger/ops)
+- [Originator Profile に関するエラーリファレンス](/error-reference/op-inspector-debugger/op)

--- a/docs/error-reference/playground/400-bad-request.md
+++ b/docs/error-reference/playground/400-bad-request.md
@@ -16,6 +16,12 @@ JSON スキーマのバリデーションエラーの場合に発生します。
 
 - 入力 JSON が期待されるスキーマ（必須項目・型・フォーマット）を満たしていない可能性があります。
 
+:::note
+
+Content Attestation Server Playground では、パラメータとして送信している Originator Profile Set の検証を行いません。
+
+:::
+
 ## 例
 
 - 以下は、入力 JSON の必須項目である `issuer` が含まれていない場合の例です。


### PR DESCRIPTION
## 変更内容

(何を・なぜ変更したか)

- CA サーバーのエラーリファレンスに OPS の検証エラーに関する案内を追加しました。
- また、Playground では OPS の検証を行っていないことを note にて記載しました。

close #407 

## 確認事項

(どうやって変更内容を確認した・してほしいか)

- プレビューにて内容をご確認ください。