### PR TITLE
Sync toppage outline with sidemenu

### DIFF
--- a/i18n/en/docusaurus-plugin-content-pages/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-pages/index.mdx
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/e0e20e4/src/pages/index.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/ef67a8d/src/pages/index.mdx
 ---
 
 # Originator Profile Docs
@@ -9,14 +9,14 @@ original: https://github.com/originator-profile/docs.originator-profile.org/blob
 
 Originator Profile Collaborative Innovation Partnership develops technologies to enable verification of the authenticity of information creators and originators. We aim for the global adoption of technologies to make the web a healthier and more transparent place.
 
-### Overview
-
-- [About Originator Profile](tech/)
-
 ### Tutorial
 
 - [Getting Started](getting-started)
 - [Originator Profile (OP) Implementation Guide](tutorial)
+
+### Overview
+
+- [About Originator Profile](tech/)
 
 ### Guides
 

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -8,14 +8,14 @@ hide_table_of_contents: true
 
 Originator Profile 技術研究組合では、情報の作成者や発信者の真正性を確認可能とするための技術を開発しています。Web の世界をより健全で透明性の高いものとするための技術のグローバルな普及を目指しています。
 
-### 概要
-
-- [Originator Profile について](tech/)
-
 ### チュートリアル
 
 - [Getting Started](getting-started)
 - [Originator Profile (OP) 対応ガイド](tutorial)
+
+### 概要
+
+- [Originator Profile について](tech/)
 
 ### ガイド
 


### PR DESCRIPTION
下記への対応

> 概要とチュートリアルの順序だけトップとサイドバーで順序が違うのはサイドバー同様に Getting Started をトップに盛っていくと良いかも。
> 
> _Originally posted by @dynamis in https://github.com/originator-profile/docs.originator-profile.org/issues/477#issuecomment-5235775994_
>             