### PR TITLE
翻訳更新[検証対象のコンテンツ・HTML要素についてのドキュメントを追加 (#461)] パーマリンクのみ更新 #482

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/tutorial/ca-target.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/tutorial/ca-target.md
@@ -1,4 +1,5 @@
 ---
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/af4601d/docs/tutorial/ca-target.md
 sidebar_position: 3
 ---
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/tutorial/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/tutorial/index.mdx
@@ -1,5 +1,5 @@
 ---
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/798ebea/docs/tutorial/index.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/af4601d/docs/tutorial/index.mdx
 ---
 
 # Originator Profile (OP) Implementation Guide


### PR DESCRIPTION
## 修正とコミットID

[検証対象のコンテンツ・HTML要素についてのドキュメントを追加 (#461)](https://github.com/originator-profile/docs.originator-profile.org/commit/af4601dfe6b9c06b9bb0cb68da66e5fdbec023b2)

commid id (https://github.com/originator-profile/docs.originator-profile.org/commit/af4601dfe6b9c06b9bb0cb68da66e5fdbec023b2)

この修正で日本語ページと翻訳ページ両方とも更新されており、パーマリンクのみの更新となるため、一括で修正更新します。

## 確認の方法

チェックスクリプトを使用してパーマリンクを更新しているので問題ないと思いますが以下の2点の確認をお願いします。

-  更新対象のファイル7件のパーマリンクのコミットIDが ( https://github.com/originator-profile/docs.originator-profile.org/commit/af4601dfe6b9c06b9bb0cb68da66e5fdbec023b2)  となっているか確認
- 翻訳ファイルそれぞれのパーマリンクが以下のように記載してあるか確認

## 対象URL 2件

1. https://github.com/originator-profile/docs.originator-profile.org/blob/af4601d/docs/tutorial/ca-target.md
2. https://github.com/originator-profile/docs.originator-profile.org/blob/af4601d/docs/tutorial/index.mdx


## レビュワー

@yoshid8s よろしくお願いします。