### PR TITLE
翻訳更新: [src/pages/index.mdx] パーマリンクのみ更新 #487

### DIFF
--- a/i18n/en/docusaurus-plugin-content-pages/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-pages/index.mdx
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-original: https://github.com/originator-profile/docs.originator-profile.org/blob/ef67a8d/src/pages/index.mdx
+original: https://github.com/originator-profile/docs.originator-profile.org/blob/22f2d27/src/pages/index.mdx
 ---
 
 # Originator Profile Docs


### PR DESCRIPTION
## 変更内容

日本語ページが更新されたため、翻訳ページ冒頭に記載するパーマリンク（翻訳対象とした日本語ページのリビジョン）のみ更新しました。

- [日本語ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/src/pages/index.mdx)
- [翻訳ページの更新履歴](https://github.com/originator-profile/docs.originator-profile.org/commits/main/i18n/en/docusaurus-plugin-content-pages/index.mdx)

履歴は同じです。(https://github.com/originator-profile/docs.originator-profile.org/commit/22f2d273bd83e98eee0bf0ce946bc6494a699f7f)


## 確認手順

該当の日本語ページのメインブランチの最新ファイルを参照し、右上にあるcommt id が今回修正したファイルの
パーマリンクのcommit id (https://github.com/originator-profile/docs.originator-profile.org/commit/22f2d273bd83e98eee0bf0ce946bc6494a699f7f) と一致していればOKです。

https://github.com/originator-profile/docs.originator-profile.org/blob/main/src/pages/index.mdx

## レビュアー

@yoshid8s レビューをお願いします。